### PR TITLE
Added PPA instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,16 @@ sudo make install
 ```
 After the intallation, restart KWin by logging out and in. Then, SierraBreezeEnhanced will appear in *System Settings &rarr; Application Style &rarr; Window Decorations*.
 
+### Ubuntu PPA
+
+Users of Ubuntu based distros (such as KDE Neon) can add the PPA and install the package by:
+
+```sh
+sudo add-apt-repository ppa:krisives/sierrabreezeenhanced
+sudo apt update
+sudo apt install sierrabreezeenhanced
+```
+
 ## Screenshots:
 
 ![Active Buttons](screenshots/ActiveButtons.gif?raw=true "Active Buttons")


### PR DESCRIPTION
I forgot about this for a while, but the PPA works for Ubuntu 18.04, 18.10, 19.04 and downstream distros like KDE Neon. It's what I use to avoid having to re-compile or check for updates since the Launchpad recipe automatically pulls from this repository.

If you don't want to merge this into the README.md that is fine too, just a suggestion.