### PR TITLE
Change "blur" to false in breeze.json

### DIFF
--- a/breeze.json
+++ b/breeze.json
@@ -9,7 +9,7 @@
         ]
     },
     "org.kde.kdecoration2": {
-        "blur": true,
+        "blur": false,
         "defaultTheme": "SierraBreezeEnhanced",
         "kcmodule": true,
         "recommendedBorderSize": "None"


### PR DESCRIPTION
Breeze itself defines "blur" in the JSON file as false:

https://github.com/KDE/breeze/blob/c96594d70a4c459eb680b86ce5a6f44c1d3a07f3/kdecoration/breeze.json#L94

However, it's worth noting that the blur effect will continue to work and that AFAIK this setting is more for "does the decoration itself use blur?" and is used in how the blur regions are calculated. I modified this to `false` and tested it and my SierraBreezeEnhanced still works as expected and Konsole still gets the blur effect including the custom titlebar rule I have which is the closest to SierraBreezeEnhanced having blur itself that I can think of.

You may be asking, why bother to set this to `false`? There are two reasons:

Firstly, if set to true then the blur effect will trigger for the entire contents of the window. I modified the blur shader to simply produce red pixels and found it interesting that it was being "activated" on windows that had no blur in them and traced it back to these lines in Kwin:

https://github.com/KDE/kwin/blob/e8fe3f2fb7195fe562a073d1a78eb05d74670cfd/effects/blur/blur.cpp#L389-L413

If blur is set to false in the JSON this doesn't happen and the effect only happens on windows where there is actually blurred contents, which drastically reduces the amount of shader overhead.

Secondly, this is related to the terribly infamous "rounded corners produce strange pixels" issues, which is described in #24 as well as [KDE Bug #395725](https://bugs.kde.org/show_bug.cgi?id=395725) where increasing the corner radius causes strange interactions with blur. This workaround of setting blur to false in this JSON file is the result of looking into ways to fix that KDE bug, which is an ongoing and more complicated task, but by setting blur to false in this JSON file we at least limit the problem to windows that actually have the blur effect enabled within them.
