### PR TITLE
Do not setButtonHovered from invalid senders

### DIFF
--- a/breezedecoration.cpp
+++ b/breezedecoration.cpp
@@ -295,7 +295,9 @@ namespace Breeze
     //________________________________________________________________
     void Decoration::setButtonHovered( bool value, Button *b )
     {
-        if( m_buttonHovered == value ) return;
+        if (value) m_lastHoveredButton = b;
+        if( m_buttonHovered == value || (!value && m_lastHoveredButton != b) ) return;
+
         m_buttonHovered = value;
         emit buttonHoveredChanged(b);
     }

--- a/breezedecoration.h
+++ b/breezedecoration.h
@@ -107,6 +107,7 @@ namespace Breeze
         //*@Decoration has a hovered button
         //@{
         bool m_buttonHovered = false;
+        Button *m_lastHoveredButton = nullptr;
         bool buttonHovered() const
         { return m_buttonHovered; }
 


### PR DESCRIPTION
@kupiqu @psifidotos @tsujan

Could you review this patch?
I'm trying to fix this issue: https://github.com/kupiqu/SierraBreezeEnhanced/pull/45#issuecomment-560122487

After debugging, I realize that, on my computer, the issue could only be reproduced by hovering between buttons very fast several times. It's so crazy. Could someone please explain?