### PR TITLE
Add kf5-kiconthemes-devel as dependency for Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ sudo pacman -S cmake extra-cmake-modules                    # Installation
 ```
 - Fedora
 ``` shell
-sudo dnf install cmake extra-cmake-modules
+sudo dnf install cmake extra-cmake-modules kf5-kiconthemes-devel
 sudo dnf install "cmake(Qt5Core)" "cmake(Qt5Gui)" "cmake(Qt5DBus)" "cmake(Qt5X11Extras)" "cmake(KF5GuiAddons)" "cmake(KF5WindowSystem)" "cmake(KF5I18n)" "cmake(KDecoration2)" "cmake(KF5CoreAddons)" "cmake(KF5ConfigWidgets)"
 ```
 


### PR DESCRIPTION
Updated readme by adding `kf5-kiconthemes-devel` as a required dependency for Fedora.

If the package is not present, cmake will crash with following error:

```
-- Could NOT find KF5IconThemes (missing: KF5IconThemes_DIR)
-- Could NOT find KF5IconThemes: found neither KF5IconThemesConfig.cmake nor kf5iconthemes-config.cmake 
CMake Error at /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
  Could NOT find KF5 (missing: IconThemes) (found version "5.110.0")
Call Stack (most recent call first):
  /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:600 (_FPHSA_FAILURE_MESSAGE)
  /usr/share/ECM/find-modules/FindKF5.cmake:93 (find_package_handle_standard_args)
  CMakeLists.txt:30 (find_package)


-- Configuring incomplete, errors occurred!
```