### PR TITLE
Add required development dependency for Arch Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ sudo apt install build-essential libkf5config-dev libkdecorations2-dev libqt5x11
 ```
 - Arch Linux
 ``` shell
+sudo pacman -S base-devel # Required development packages
 sudo pacman -S kdecoration qt5-declarative qt5-x11extras    # Decoration
 sudo pacman -S cmake extra-cmake-modules                    # Installation
 ```


### PR DESCRIPTION
I tried compiling this project on Manjaro (arch based distro), and all the build commands failed because base-devel package was not present, after installing base-devel, the project build successfully. 

This PR adds base-devel as a required package since it is required to build this (or any C/C++) project