### PR TITLE
Update build dependencies for Fedora in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ sudo pacman -S cmake extra-cmake-modules                    # Installation
 ``` shell
 sudo dnf install cmake extra-cmake-modules kf6-kiconthemes-devel
 sudo dnf install "cmake(Qt6Core)" "cmake(Qt6Gui)" "cmake(Qt6DBus)" "cmake(KF6GuiAddons)" "cmake(KF6WindowSystem)" "cmake(KF6I18n)" "cmake(KDecoration2)" "cmake(KF6CoreAddons)" "cmake(KF6ConfigWidgets)"
-sudo dnf install qt6-qt5compat-devel kf6-kcmutils-devel
+sudo dnf install qt6-qt5compat-devel kf6-kcmutils-devel qt6-qtbase-private-devel
 ```
 
 - Alpine Linux

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ sudo pacman -S cmake extra-cmake-modules                    # Installation
 ``` shell
 sudo dnf install cmake extra-cmake-modules kf6-kiconthemes-devel
 sudo dnf install "cmake(Qt6Core)" "cmake(Qt6Gui)" "cmake(Qt6DBus)" "cmake(KF6GuiAddons)" "cmake(KF6WindowSystem)" "cmake(KF6I18n)" "cmake(KDecoration2)" "cmake(KF6CoreAddons)" "cmake(KF6ConfigWidgets)"
+sudo dnf install qt6-qt5compat-devel kf6-kcmutils-devel
 ```
 
 - Alpine Linux


### PR DESCRIPTION
This resolves the compilation issues on latest Fedora due to incomplete build dependencies

## System Specifications
Operating System: Fedora Linux 40
KDE Plasma Version: 6.1.5
KDE Frameworks Version: 6.6.0
Qt Version: 6.7.2
Kernel Version: 6.10.12-200.fc40.x86_64 (64-bit)
Graphics Platform: Wayland
Processors: 6 × Intel® Core™ i5-8400 CPU @ 2.80GHz
Memory: 15.5 GiB of RAM
Graphics Processor: NVIDIA GeForce GTX 1660 Ti/PCIe/SSE2
Manufacturer: Gigabyte Technology Co., Ltd.
Product Name: B360M GAMING HD

## Problem Description

While compiling from source I encountered errors in the build process

```bash
CMake Error at CMakeLists.txt:54 (find_package):  Found package configuration file:    /usr/lib64/cmake/Qt6/Qt6Config.cmake  but it set Qt6_FOUND to FALSE so package "Qt6" is considered to be NOT  FOUND.  Reason given by package:  Failed to find required Qt component "Core5Compat".  Expected Config file at  "/usr/lib64/cmake/Qt6Core5Compat/Qt6Core5CompatConfig.cmake" does NOT exist  Configuring with --debug-find-pkg=Qt6Core5Compat might reveal details why  the package was not found.  Configuring with -DQT_DEBUG_FIND_PACKAGE=ON will print the values of some  of the path variables that find_package uses to try and find the package.
```

and 

```bash
imported target "Qt6::GuiPrivate" includes non-existent path    "/usr/include/qt6/QtGui/6.7.2"  in its INTERFACE_INCLUDE_DIRECTORIES.  Possible reasons include:  * The path was deleted, renamed, or moved to another location.  * An install or uninstall procedure did not complete successfully.  * The installation package was faulty and references files it does not  provide. CMake Error in config/CMakeLists.txt:  Imported target "Qt6::GuiPrivate" includes non-existent path    "/usr/include/qt6/QtGui/6.7.2"  in its INTERFACE_INCLUDE_DIRECTORIES.  Possible reasons include:  * The path was deleted, renamed, or moved to another location.  * An install or uninstall procedure did not complete successfully.  * The installation package was faulty and references files it does not  provide. CMake Error in CMakeLists.txt:  Imported target "Qt6::GuiPrivate" includes non-existent path    "/usr/include/qt6/QtGui/6.7.2"  in its INTERFACE_INCLUDE_DIRECTORIES.  Possible reasons include:  * The path was deleted, renamed, or moved to another location.  * An install or uninstall procedure did not complete successfully.  * The installation package was faulty and references files it does not  provide. CMake Error in config/CMakeLists.txt:  Imported target "Qt6::GuiPrivate" includes non-existent path    "/usr/include/qt6/QtGui/6.7.2"  in its INTERFACE_INCLUDE_DIRECTORIES.  Possible reasons include:  * The path was deleted, renamed, or moved to another location.  * An install or uninstall procedure did not complete successfully.  * The installation package was faulty and references files it does not  provide.
```
## Solution
Turns out there were 3 packages missing in dependencies. 
` qt6-qt5compat-devel ` , `kf6-kcmutils-devel` , `qt6-qtbase-private-devel`

So fixed it by installing these packages using dnf and updated them in README.md