### PR TITLE
Migrating KDecoration2 to KDecoration3 (Porting SBE to Plasma 6.3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 build
+.vscode
+.cache

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ include(GenerateExportHeader)
 include(KDEClangFormat)
 # include(GtkUpdateIconCache)
 
-find_package(KDecoration2 REQUIRED)
+find_package(KDecoration3 REQUIRED)
 
 if(NOT WIN32 AND NOT APPLE)
   find_package(KF6KCMUtils ${KF6_MIN_VERSION})
@@ -111,7 +111,7 @@ target_link_libraries(
   sierrabreezeenhanced
   PUBLIC Qt6::Core Qt6::Gui Qt6::DBus Qt6::Core5Compat
   PRIVATE sierrabreezeenhancedcommon6
-          KDecoration2::KDecoration
+          KDecoration3::KDecoration
           KF6::IconThemes
           KF6::ConfigCore
           KF6::CoreAddons

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ sudo pacman -S cmake extra-cmake-modules                    # Installation
 - Fedora
 ``` shell
 sudo dnf install cmake extra-cmake-modules kf6-kiconthemes-devel
-sudo dnf install "cmake(Qt6Core)" "cmake(Qt6Gui)" "cmake(Qt6DBus)" "cmake(KF6GuiAddons)" "cmake(KF6WindowSystem)" "cmake(KF6I18n)" "cmake(KDecoration2)" "cmake(KF6CoreAddons)" "cmake(KF6ConfigWidgets)"
+sudo dnf install "cmake(Qt6Core)" "cmake(Qt6Gui)" "cmake(Qt6DBus)" "cmake(KF6GuiAddons)" "cmake(KF6WindowSystem)" "cmake(KF6I18n)" "cmake(KDecoration3)" "cmake(KF6CoreAddons)" "cmake(KF6ConfigWidgets)"
 sudo dnf install qt6-qt5compat-devel kf6-kcmutils-devel qt6-qtbase-private-devel
 ```
 

--- a/breezebutton.cpp
+++ b/breezebutton.cpp
@@ -20,7 +20,7 @@
  */
 #include "breezebutton.h"
 
-#include <KDecoration2/DecoratedClient>
+#include <KDecoration3/DecoratedWindow>
 #include <KColorUtils>
 #include <KIconLoader>
 
@@ -30,9 +30,9 @@
 namespace Breeze
 {
 
-    using KDecoration2::ColorRole;
-    using KDecoration2::ColorGroup;
-    using KDecoration2::DecorationButtonType;
+    using KDecoration3::ColorRole;
+    using KDecoration3::ColorGroup;
+    using KDecoration3::DecorationButtonType;
 
 
     //__________________________________________________________________
@@ -57,9 +57,9 @@ namespace Breeze
         setIconSize(QSize( height, height ));
 
         // connections
-        connect(decoration->client(), SIGNAL(iconChanged(QIcon)), this, SLOT(update()));
-        connect(decoration->settings().get(), &KDecoration2::DecorationSettings::reconfigured, this, &Button::reconfigure);
-        connect( this, &KDecoration2::DecorationButton::hoveredChanged, this, &Button::updateAnimationState );
+        connect(decoration->window(), SIGNAL(iconChanged(QIcon)), this, SLOT(update()));
+        connect(decoration->settings().get(), &KDecoration3::DecorationSettings::reconfigured, this, &Button::reconfigure);
+        connect( this, &KDecoration3::DecorationButton::hoveredChanged, this, &Button::updateAnimationState );
 
         if (decoration->objectName() == "applet-window-buttons") {
             connect( this, &Button::hoveredChanged, [=](bool hovered){
@@ -83,7 +83,7 @@ namespace Breeze
     }
 
     //__________________________________________________________________
-    Button *Button::create(DecorationButtonType type, KDecoration2::Decoration *decoration, QObject *parent)
+    Button *Button::create(DecorationButtonType type, KDecoration3::Decoration *decoration, QObject *parent)
     {
         if (auto d = qobject_cast<Decoration*>(decoration))
         {
@@ -92,32 +92,32 @@ namespace Breeze
             {
 
                 case DecorationButtonType::Close:
-                b->setVisible( d->client()->isCloseable() );
-                QObject::connect(d->client(), &KDecoration2::DecoratedClient::closeableChanged, b, &Breeze::Button::setVisible );
+                b->setVisible( d->window()->isCloseable() );
+                QObject::connect(d->window(), &KDecoration3::DecoratedWindow::closeableChanged, b, &Breeze::Button::setVisible );
                 break;
 
                 case DecorationButtonType::Maximize:
-                b->setVisible( d->client()->isMaximizeable() );
-                QObject::connect(d->client(), &KDecoration2::DecoratedClient::maximizeableChanged, b, &Breeze::Button::setVisible );
+                b->setVisible( d->window()->isMaximizeable() );
+                QObject::connect(d->window(), &KDecoration3::DecoratedWindow::maximizeableChanged, b, &Breeze::Button::setVisible );
                 break;
 
                 case DecorationButtonType::Minimize:
-                b->setVisible( d->client()->isMinimizeable() );
-                QObject::connect(d->client(), &KDecoration2::DecoratedClient::minimizeableChanged, b, &Breeze::Button::setVisible );
+                b->setVisible( d->window()->isMinimizeable() );
+                QObject::connect(d->window(), &KDecoration3::DecoratedWindow::minimizeableChanged, b, &Breeze::Button::setVisible );
                 break;
 
                 case DecorationButtonType::ContextHelp:
-                b->setVisible( d->client()->providesContextHelp() );
-                QObject::connect(d->client(), &KDecoration2::DecoratedClient::providesContextHelpChanged, b, &Breeze::Button::setVisible );
+                b->setVisible( d->window()->providesContextHelp() );
+                QObject::connect(d->window(), &KDecoration3::DecoratedWindow::providesContextHelpChanged, b, &Breeze::Button::setVisible );
                 break;
 
                 case DecorationButtonType::Shade:
-                b->setVisible( d->client()->isShadeable() );
-                QObject::connect(d->client(), &KDecoration2::DecoratedClient::shadeableChanged, b, &Breeze::Button::setVisible );
+                b->setVisible( d->window()->isShadeable() );
+                QObject::connect(d->window(), &KDecoration3::DecoratedWindow::shadeableChanged, b, &Breeze::Button::setVisible );
                 break;
 
                 case DecorationButtonType::Menu:
-                QObject::connect(d->client(), &KDecoration2::DecoratedClient::iconChanged, b, [b]() { b->update(); });
+                QObject::connect(d->window(), &KDecoration3::DecoratedWindow::iconChanged, b, [b]() { b->update(); });
                 break;
 
                 default: break;
@@ -131,7 +131,7 @@ namespace Breeze
     }
 
     //__________________________________________________________________
-    void Button::paint(QPainter *painter, const QRect &repaintRegion)
+    void Button::paint(QPainter *painter, const QRectF &repaintRegion)
     {
         Q_UNUSED(repaintRegion)
 
@@ -154,17 +154,17 @@ namespace Breeze
             painter->translate( 0.1*width, 0.1*width );
             if (auto deco =  qobject_cast<Decoration*>(decoration())) {
               const QPalette activePalette = KIconLoader::global()->customPalette();
-              QPalette palette = decoration()->client()->palette();
+              QPalette palette = decoration()->window()->palette();
               palette.setColor(QPalette::WindowText, deco->fontColor());
               KIconLoader::global()->setCustomPalette(palette);
-              decoration()->client()->icon().paint(painter, iconRect.toRect());
+              decoration()->window()->icon().paint(painter, iconRect.toRect());
               if (activePalette == QPalette()) {
                 KIconLoader::global()->resetPalette();
               }    else {
                 KIconLoader::global()->setCustomPalette(palette);
               }
             } else {
-              decoration()->client()->icon().paint(painter, iconRect.toRect());
+              decoration()->window()->icon().paint(painter, iconRect.toRect());
             }
 
         } else {
@@ -656,7 +656,7 @@ namespace Breeze
           painter->translate( 4, 4 );
         }
 
-        bool inactiveWindow( d && !d->client()->isActive() );
+        bool inactiveWindow( d && !d->window()->isActive() );
         bool isMatchTitleBarColor( d && d->internalSettings()->matchColorForTitleBar() );
 
         QColor darkSymbolColor( ( inactiveWindow && isMatchTitleBarColor ) ? QColor(81, 102, 107) : QColor(34, 45, 50) );
@@ -1065,7 +1065,7 @@ namespace Breeze
           painter->translate( 4, 4 );
         }
 
-        bool inactiveWindow( d && !d->client()->isActive() );
+        bool inactiveWindow( d && !d->window()->isActive() );
         bool isMatchTitleBarColor( d && d->internalSettings()->matchColorForTitleBar() );
 
         QColor darkSymbolColor( ( inactiveWindow && isMatchTitleBarColor ) ? QColor(81, 102, 107) : QColor(34, 45, 50) );
@@ -1492,7 +1492,7 @@ namespace Breeze
           painter->translate( 4, 4 );
         }
 
-        bool inactiveWindow( d && !d->client()->isActive() );
+        bool inactiveWindow( d && !d->window()->isActive() );
         bool useActiveButtonStyle( d && d->internalSettings()->buttonStyle() == 5 );
         bool useInactiveButtonStyle( d && d->internalSettings()->buttonStyle() == 6 );
         bool isMatchTitleBarColor( d && d->internalSettings()->matchColorForTitleBar() );
@@ -1989,7 +1989,7 @@ namespace Breeze
           painter->translate( 4, 4 );
         }
 
-        bool inactiveWindow( d && !d->client()->isActive() );
+        bool inactiveWindow( d && !d->window()->isActive() );
         bool useActiveButtonStyle( d && d->internalSettings()->buttonStyle() == 8 );
         bool useInactiveButtonStyle( d && d->internalSettings()->buttonStyle() == 9 );
         bool isMatchTitleBarColor( d && d->internalSettings()->matchColorForTitleBar() );
@@ -2497,7 +2497,7 @@ namespace Breeze
 
         auto d = qobject_cast<Decoration*>( decoration() );
 
-        bool inactiveWindow( d && !d->client()->isActive() );
+        bool inactiveWindow( d && !d->window()->isActive() );
         bool isMatchTitleBarColor( d && d->internalSettings()->matchColorForTitleBar() );
 
         QColor darkSymbolColor( ( inactiveWindow && isMatchTitleBarColor ) ? QColor(81, 102, 107) : QColor(34, 45, 50) );
@@ -2832,7 +2832,7 @@ namespace Breeze
 
         auto d = qobject_cast<Decoration*>( decoration() );
 
-        bool inactiveWindow( d && !d->client()->isActive() );
+        bool inactiveWindow( d && !d->window()->isActive() );
         bool isMatchTitleBarColor( d && d->internalSettings()->matchColorForTitleBar() );
 
         QColor darkSymbolColor( ( inactiveWindow && isMatchTitleBarColor ) ? QColor(81, 102, 107) : QColor(34, 45, 50) );
@@ -3943,7 +3943,7 @@ namespace Breeze
 
         }
 
-        auto c = d->client();
+        auto c = d->window();
         if( isPressed() ) {
 
             if( type() == DecorationButtonType::Close ) return c->color( ColorGroup::Warning, ColorRole::Foreground );

--- a/breezebutton.h
+++ b/breezebutton.h
@@ -151,7 +151,7 @@ namespace Breeze
         QPointF m_offset;
 
         //* icon size
-        QSize m_iconSize;
+        QSizeF m_iconSize;
 
         //* active state change opacity
         qreal m_opacity = 0;

--- a/breezebutton.h
+++ b/breezebutton.h
@@ -21,7 +21,7 @@
 * You should have received a copy of the GNU General Public License
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-#include <KDecoration2/DecorationButton>
+#include <KDecoration3/DecorationButton>
 #include "breezedecoration.h"
 
 #include <QHash>
@@ -34,7 +34,7 @@ class QVariantAnimation;
 namespace Breeze
 {
 
-    class Button : public KDecoration2::DecorationButton
+    class Button : public KDecoration3::DecorationButton
     {
         Q_OBJECT
 
@@ -47,10 +47,10 @@ namespace Breeze
         virtual ~Button() = default;
 
         //* button creation
-        static Button *create(KDecoration2::DecorationButtonType type, KDecoration2::Decoration *decoration, QObject *parent);
+        static Button *create(KDecoration3::DecorationButtonType type, KDecoration3::Decoration *decoration, QObject *parent);
 
         //* render
-        virtual void paint(QPainter *painter, const QRect &repaintRegion) override;
+        virtual void paint(QPainter *painter, const QRectF &repaintRegion) override;
 
         //* flag
         enum Flag
@@ -109,7 +109,7 @@ namespace Breeze
         private:
 
         //* private constructor
-        explicit Button(KDecoration2::DecorationButtonType type, Decoration *decoration, QObject *parent = nullptr);
+        explicit Button(KDecoration3::DecorationButtonType type, Decoration *decoration, QObject *parent = nullptr);
 
         //* draw button icon
         void drawIconPlasma( QPainter *) const;

--- a/breezedecoration.cpp
+++ b/breezedecoration.cpp
@@ -512,7 +512,7 @@ namespace Breeze
         BoxShadowRenderer shadowRenderer;
         shadowRenderer.setBorderRadius(0.5 * s->smallSpacing() * (m_internalSettings->cornerRadius() + 0.5));
         shadowRenderer.setBoxSize(boxSize);
-        shadowRenderer.setDevicePixelRatio(1.0); // TODO: Create HiDPI shadows?
+        
 
         const qreal strength = static_cast<qreal>(g_shadowStrength) / 255.0;
         shadowRenderer.addShadow(params.shadow1.offset, params.shadow1.radius,
@@ -594,7 +594,7 @@ namespace Breeze
         BoxShadowRenderer shadowRenderer;
         shadowRenderer.setBorderRadius(0.5 * s->smallSpacing() * (m_internalSettings->cornerRadius() + 0.5));
         shadowRenderer.setBoxSize(boxSize);
-        shadowRenderer.setDevicePixelRatio(1.0); // TODO: Create HiDPI shadows?
+        
 
         const qreal strength = static_cast<qreal>(g_shadowStrengthInactiveWindows) / 255.0;
         shadowRenderer.addShadow(params.shadow1.offset, params.shadow1.radius,
@@ -883,9 +883,9 @@ namespace Breeze
         }
 
         // padding
-        const int vPadding = isTopEdge() ? 0 : s->smallSpacing() * Metrics::TitleBar_TopMargin;
-        const int hPadding = s->smallSpacing() * Metrics::TitleBar_SideMargin;
-        const int hMargin = 0.5 * s->smallSpacing() * m_internalSettings->buttonPadding() + 0.5 * s->smallSpacing() * m_internalSettings->hOffset();
+        const double vPadding = isTopEdge() ? 0 : s->smallSpacing() * Metrics::TitleBar_TopMargin;
+        const double hPadding = s->smallSpacing() * Metrics::TitleBar_SideMargin;
+        const double hMargin = 0.5 * s->smallSpacing() * m_internalSettings->buttonPadding() + 0.5 * s->smallSpacing() * m_internalSettings->hOffset();
 
         // left buttons
         if (!m_leftButtons->buttons().isEmpty())
@@ -1072,7 +1072,7 @@ namespace Breeze
     //________________________________________________________________
     int Decoration::buttonHeight() const
     {
-        const int baseSize = settings()->gridUnit();
+        const double baseSize = settings()->gridUnit();
         switch (m_internalSettings->buttonSize())
         {
         case InternalSettings::ButtonTiny:

--- a/breezedecoration.cpp
+++ b/breezedecoration.cpp
@@ -1,24 +1,24 @@
 /*
-* Copyright 2014  Martin Gräßlin <mgraesslin@kde.org>
-* Copyright 2014  Hugo Pereira Da Costa <hugo.pereira@free.fr>
-* Copyright 2018  Vlad Zahorodnii <vlad.zahorodnii@kde.org>
-*
-* This program is free software; you can redistribute it and/or
-* modify it under the terms of the GNU General Public License as
-* published by the Free Software Foundation; either version 2 of
-* the License or (at your option) version 3 or any later version
-* accepted by the membership of KDE e.V. (or its successor approved
-* by the membership of KDE e.V.), which shall act as a proxy
-* defined in Section 14 of version 3 of the license.
-*
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU General Public License for more details.
-*
-* You should have received a copy of the GNU General Public License
-* along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*/
+ * Copyright 2014  Martin Gräßlin <mgraesslin@kde.org>
+ * Copyright 2014  Hugo Pereira Da Costa <hugo.pereira@free.fr>
+ * Copyright 2018  Vlad Zahorodnii <vlad.zahorodnii@kde.org>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of
+ * the License or (at your option) version 3 or any later version
+ * accepted by the membership of KDE e.V. (or its successor approved
+ * by the membership of KDE e.V.), which shall act as a proxy
+ * defined in Section 14 of version 3 of the license.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 
 #include "breezedecoration.h"
 
@@ -32,10 +32,10 @@
 
 #include "breezeboxshadowrenderer.h"
 
-#include <KDecoration2/DecoratedClient>
-#include <KDecoration2/DecorationButtonGroup>
-#include <KDecoration2/DecorationSettings>
-#include <KDecoration2/DecorationShadow>
+#include <KDecoration3/DecoratedWindow>
+#include <KDecoration3/DecorationButtonGroup>
+#include <KDecoration3/DecorationSettings>
+#include <KDecoration3/DecorationShadow>
 
 #include <KConfigGroup>
 #include <KColorUtils>
@@ -62,34 +62,31 @@ K_PLUGIN_FACTORY_WITH_JSON(
 
 namespace
 {
-    struct ShadowParams {
+    struct ShadowParams
+    {
         ShadowParams()
-            : offset(QPoint(0, 0))
-            , radius(0)
-            , opacity(0) {}
+            : offset(QPoint(0, 0)), radius(0), opacity(0) {}
 
         ShadowParams(const QPoint &offset, int radius, qreal opacity)
-            : offset(offset)
-            , radius(radius)
-            , opacity(opacity) {}
+            : offset(offset), radius(radius), opacity(opacity) {}
 
         QPoint offset;
         int radius;
         qreal opacity;
     };
 
-    struct CompositeShadowParams {
+    struct CompositeShadowParams
+    {
         CompositeShadowParams() = default;
 
         CompositeShadowParams(
-                const QPoint &offset,
-                const ShadowParams &shadow1,
-                const ShadowParams &shadow2)
-            : offset(offset)
-            , shadow1(shadow1)
-            , shadow2(shadow2) {}
+            const QPoint &offset,
+            const ShadowParams &shadow1,
+            const ShadowParams &shadow2)
+            : offset(offset), shadow1(shadow1), shadow2(shadow2) {}
 
-        bool isNone() const {
+        bool isNone() const
+        {
             return qMax(shadow1.radius, shadow2.radius) == 0;
         }
 
@@ -120,12 +117,12 @@ namespace
         CompositeShadowParams(
             QPoint(0, 16),
             ShadowParams(QPoint(0, 0), 64, 0.7),
-            ShadowParams(QPoint(0, -8), 32, 0.1))
-    };
+            ShadowParams(QPoint(0, -8), 32, 0.1))};
 
     inline CompositeShadowParams lookupShadowParams(int size)
     {
-        switch (size) {
+        switch (size)
+        {
         case Breeze::InternalSettings::ShadowNone:
             return s_shadowParams[0];
         case Breeze::InternalSettings::ShadowSmall:
@@ -144,7 +141,8 @@ namespace
 
     inline CompositeShadowParams lookupShadowParamsInactiveWindows(int size)
     {
-        switch (size) {
+        switch (size)
+        {
         case Breeze::InternalSettings::ShadowNoneInactiveWindows:
             return s_shadowParams[0];
         case Breeze::InternalSettings::ShadowSmallInactiveWindows:
@@ -165,15 +163,15 @@ namespace
 namespace Breeze
 {
 
-    using KDecoration2::ColorRole;
-    using KDecoration2::ColorGroup;
+    using KDecoration3::ColorGroup;
+    using KDecoration3::ColorRole;
 
     //________________________________________________________________
     static int g_sDecoCount = 0;
     static int g_shadowSizeEnum = InternalSettings::ShadowLarge;
     static int g_shadowStrength = 255;
     static QColor g_shadowColor = Qt::black;
-    static std::shared_ptr<KDecoration2::DecorationShadow> g_sShadow;
+    static std::shared_ptr<KDecoration3::DecorationShadow> g_sShadow;
     static bool g_specificShadowsInactiveWindows = false;
     static int g_shadowSizeEnumInactiveWindows = InternalSettings::ShadowLarge;
     static int g_shadowStrengthInactiveWindows = 255;
@@ -181,8 +179,7 @@ namespace Breeze
 
     //________________________________________________________________
     Decoration::Decoration(QObject *parent, const QVariantList &args)
-        : KDecoration2::Decoration(parent, args)
-        , m_animation( new QVariantAnimation( this ) )
+        : KDecoration3::Decoration(parent, args), m_animation(new QVariantAnimation(this))
     {
         g_sDecoCount++;
     }
@@ -191,67 +188,73 @@ namespace Breeze
     Decoration::~Decoration()
     {
         g_sDecoCount--;
-        if (g_sDecoCount == 0) {
+        if (g_sDecoCount == 0)
+        {
             // last deco destroyed, clean up shadow
             g_sShadow.reset();
         }
 
         deleteSizeGrip();
-
     }
 
     //________________________________________________________________
-    void Decoration::setOpacity( qreal value )
+    void Decoration::setOpacity(qreal value)
     {
-        if( m_opacity == value ) return;
+        if (m_opacity == value)
+            return;
         m_opacity = value;
         update();
 
-        if( m_sizeGrip ) m_sizeGrip->update();
+        if (m_sizeGrip)
+            m_sizeGrip->update();
     }
 
     //________________________________________________________________
     QColor Decoration::titleBarColor() const
     {
-        QColor titleBarColor( this->rawTitleBarColor() );
-        QColor outlineColor( this->outlineColor() );
+        QColor titleBarColor(this->rawTitleBarColor());
+        QColor outlineColor(this->outlineColor());
 
-        auto c( client() );
-        if ( drawBackgroundGradient() ) // && c->isActive() )
+        auto c(window());
+        if (drawBackgroundGradient()) // && c->isActive() )
         {
-            if ( c->isActive() )
+            if (c->isActive())
             {
-                if ( qGray(titleBarColor.rgb()) > 69 ) {
-                    if ( outlineColor.isValid() )
+                if (qGray(titleBarColor.rgb()) > 69)
+                {
+                    if (outlineColor.isValid())
                         titleBarColor = titleBarColor.darker(115);
                 }
-                else {
-                    if ( outlineColor.isValid() )
+                else
+                {
+                    if (outlineColor.isValid())
                         titleBarColor = titleBarColor.lighter(115);
                 }
             }
             else
             {
-                if ( qGray(titleBarColor.rgb()) > 69 ) {
-                    if ( outlineColor.isValid() )
+                if (qGray(titleBarColor.rgb()) > 69)
+                {
+                    if (outlineColor.isValid())
                         titleBarColor = titleBarColor.darker(110);
                 }
-                else {
-                    if ( outlineColor.isValid() )
+                else
+                {
+                    if (outlineColor.isValid())
                         titleBarColor = titleBarColor.lighter(110);
                 }
             }
         }
-        else if ( outlineColor.isValid() && c->isActive() )
+        else if (outlineColor.isValid() && c->isActive())
         {
-            if ( qGray(titleBarColor.rgb()) > 69 )
+            if (qGray(titleBarColor.rgb()) > 69)
                 titleBarColor = titleBarColor.darker(115);
             else
                 titleBarColor = titleBarColor.lighter(115);
         }
-        else if ( outlineColor.isValid() )
+        else if (outlineColor.isValid())
         {
-            if ( qGray(titleBarColor.rgb()) > 69 )
+            if (qGray(titleBarColor.rgb()) > 69)
                 titleBarColor = titleBarColor.darker(110);
             else
                 titleBarColor = titleBarColor.lighter(110);
@@ -262,9 +265,10 @@ namespace Breeze
     //________________________________________________________________
     QColor Decoration::outlineColor() const
     {
-        if( !m_internalSettings->drawTitleBarSeparator() ) return QColor();
+        if (!m_internalSettings->drawTitleBarSeparator())
+            return QColor();
 
-        QColor titleBarColor ( rawTitleBarColor() );
+        QColor titleBarColor(rawTitleBarColor());
 
         uint r = qRed(titleBarColor.rgb());
         uint g = qGreen(titleBarColor.rgb());
@@ -273,10 +277,10 @@ namespace Breeze
         qreal colorConditional = 0.299 * static_cast<qreal>(r) + 0.587 * static_cast<qreal>(g) + 0.114 * static_cast<qreal>(b);
 
         QColor outlineColor;
-        if ( colorConditional > 69 ) // 255 -186
-          outlineColor = titleBarColor.darker(140);
+        if (colorConditional > 69) // 255 -186
+            outlineColor = titleBarColor.darker(140);
         else
-          outlineColor = titleBarColor.lighter(140);
+            outlineColor = titleBarColor.lighter(140);
 
         return outlineColor;
     }
@@ -284,20 +288,24 @@ namespace Breeze
     //________________________________________________________________
     QColor Decoration::rawTitleBarColor() const
     {
-        auto c = client();
+        auto c = window();
         QColor titleBarColor;
 
-        if ( !matchColorForTitleBar() ) {
-            if( m_animation->state() == QAbstractAnimation::Running )
+        if (!matchColorForTitleBar())
+        {
+            if (m_animation->state() == QAbstractAnimation::Running)
             {
                 titleBarColor = KColorUtils::mix(
-                    c->color( ColorGroup::Inactive, ColorRole::TitleBar ),
-                    c->color( ColorGroup::Active, ColorRole::TitleBar ),
-                    m_opacity );
-            } else titleBarColor = c->color( c->isActive() ? ColorGroup::Active : ColorGroup::Inactive, ColorRole::TitleBar );
+                    c->color(ColorGroup::Inactive, ColorRole::TitleBar),
+                    c->color(ColorGroup::Active, ColorRole::TitleBar),
+                    m_opacity);
+            }
+            else
+                titleBarColor = c->color(c->isActive() ? ColorGroup::Active : ColorGroup::Inactive, ColorRole::TitleBar);
         }
-        else {
-          titleBarColor = c->palette().color(QPalette::Window);
+        else
+        {
+            titleBarColor = c->palette().color(QPalette::Window);
         }
         titleBarColor.setAlpha(titleBarAlpha());
         return titleBarColor;
@@ -306,22 +314,26 @@ namespace Breeze
     //________________________________________________________________
     QColor Decoration::fontColor() const
     {
-         auto c = client();
+        auto c = window();
 
-         if (systemForegroundColor()) {
-             if( m_animation->state() == QAbstractAnimation::Running ) {
-                 return KColorUtils::mix(
-                        c->color( ColorGroup::Inactive, ColorRole::Foreground ),
-                        c->color( ColorGroup::Active, ColorRole::Foreground ),
-                        m_opacity );
-             }
-             else {
-                 return  c->color( c->isActive() ? ColorGroup::Active : ColorGroup::Inactive, ColorRole::Foreground );
-             }
+        if (systemForegroundColor())
+        {
+            if (m_animation->state() == QAbstractAnimation::Running)
+            {
+                return KColorUtils::mix(
+                    c->color(ColorGroup::Inactive, ColorRole::Foreground),
+                    c->color(ColorGroup::Active, ColorRole::Foreground),
+                    m_opacity);
+            }
+            else
+            {
+                return c->color(c->isActive() ? ColorGroup::Active : ColorGroup::Inactive, ColorRole::Foreground);
+            }
         }
-        else {
-            QColor darkTextColor( !c->isActive() && matchColorForTitleBar() ? QColor(81, 102, 107) : QColor(34, 45, 50) );
-            QColor lightTextColor( !c->isActive() && matchColorForTitleBar() ? QColor(192, 193, 194) : QColor(250, 251, 252) );
+        else
+        {
+            QColor darkTextColor(!c->isActive() && matchColorForTitleBar() ? QColor(81, 102, 107) : QColor(34, 45, 50));
+            QColor lightTextColor(!c->isActive() && matchColorForTitleBar() ? QColor(192, 193, 194) : QColor(250, 251, 252));
 
             QColor titleBarColor = this->titleBarColor();
 
@@ -333,18 +345,18 @@ namespace Breeze
             // qreal titleBarLuminance = (0.2126 * static_cast<qreal>(r) + 0.7152 * static_cast<qreal>(g) + 0.0722 * static_cast<qreal>(b)) / 255.;
             // if ( titleBarLuminance >  sqrt(1.05 * 0.05) - 0.05 )
             qreal colorConditional = 0.299 * static_cast<qreal>(r) + 0.587 * static_cast<qreal>(g) + 0.114 * static_cast<qreal>(b);
-            if ( colorConditional > 186 || g > 186 ) // ( colorConditional > 186 ) // if ( colorConditional > 150 )
+            if (colorConditional > 186 || g > 186) // ( colorConditional > 186 ) // if ( colorConditional > 150 )
                 return darkTextColor;
             else
                 return lightTextColor;
         }
-
     }
 
     //________________________________________________________________
-    void Decoration::setButtonHovered( bool value )
+    void Decoration::setButtonHovered(bool value)
     {
-        if (m_buttonHovered == value) {
+        if (m_buttonHovered == value)
+        {
             return;
         }
         m_buttonHovered = value;
@@ -354,75 +366,74 @@ namespace Breeze
     //________________________________________________________________
     void Decoration::hoverMoveEvent(QHoverEvent *event)
     {
-        if (objectName() != "applet-window-buttons") {
-            const bool groupContains = m_leftButtons->geometry().contains(event->posF()) || m_rightButtons->geometry().contains(event->posF());
+        if (objectName() != "applet-window-buttons")
+        {
+            const bool groupContains = m_leftButtons->geometry().contains(event->position()) || m_rightButtons->geometry().contains(event->position());
             setButtonHovered(groupContains);
         }
 
-        KDecoration2::Decoration::hoverMoveEvent(event);
+        KDecoration3::Decoration::hoverMoveEvent(event);
     }
 
     //________________________________________________________________
     bool Decoration::init()
     {
-        auto c = client();
+        auto c = window();
 
         // active state change animation
         // It is important start and end value are of the same type, hence 0.0 and not just 0
-        m_animation->setStartValue( 0.0 );
-        m_animation->setEndValue( 1.0 );
+        m_animation->setStartValue(0.0);
+        m_animation->setEndValue(1.0);
         // Linear to have the same easing as Breeze animations
-        m_animation->setEasingCurve( QEasingCurve::Linear );
-        connect(m_animation, &QVariantAnimation::valueChanged, this, [this](const QVariant &value) {
-            setOpacity(value.toReal());
-        });
+        m_animation->setEasingCurve(QEasingCurve::Linear);
+        connect(m_animation, &QVariantAnimation::valueChanged, this, [this](const QVariant &value)
+                { setOpacity(value.toReal()); });
 
         reconfigure();
         updateTitleBar();
         auto s = settings();
-        connect(s.get(), &KDecoration2::DecorationSettings::borderSizeChanged, this, &Decoration::recalculateBorders);
-        connect(s.get(), &KDecoration2::DecorationSettings::borderSizeChanged, this, &Decoration::updateBlur); //for the case when a border with transparency
+        connect(s.get(), &KDecoration3::DecorationSettings::borderSizeChanged, this, &Decoration::recalculateBorders);
+        connect(s.get(), &KDecoration3::DecorationSettings::borderSizeChanged, this, &Decoration::updateBlur); // for the case when a border with transparency
 
         // a change in font might cause the borders to change
-        connect(s.get(), &KDecoration2::DecorationSettings::fontChanged, this, &Decoration::recalculateBorders); // recalculateBorders();
-        connect(s.get(), &KDecoration2::DecorationSettings::fontChanged, this, &Decoration::updateBlur); //for the case when a border with transparency
-        connect(s.get(), &KDecoration2::DecorationSettings::spacingChanged, this, &Decoration::recalculateBorders);
-        connect(s.get(), &KDecoration2::DecorationSettings::spacingChanged, this, &Decoration::updateBlur); //for the case when a border with transparency
+        connect(s.get(), &KDecoration3::DecorationSettings::fontChanged, this, &Decoration::recalculateBorders); // recalculateBorders();
+        connect(s.get(), &KDecoration3::DecorationSettings::fontChanged, this, &Decoration::updateBlur);         // for the case when a border with transparency
+        connect(s.get(), &KDecoration3::DecorationSettings::spacingChanged, this, &Decoration::recalculateBorders);
+        connect(s.get(), &KDecoration3::DecorationSettings::spacingChanged, this, &Decoration::updateBlur); // for the case when a border with transparency
 
         // buttons
-        connect(s.get(), &KDecoration2::DecorationSettings::spacingChanged, this, &Decoration::updateButtonsGeometryDelayed);
-        connect(s.get(), &KDecoration2::DecorationSettings::decorationButtonsLeftChanged, this, &Decoration::updateButtonsGeometryDelayed);
-        connect(s.get(), &KDecoration2::DecorationSettings::decorationButtonsRightChanged, this, &Decoration::updateButtonsGeometryDelayed);
+        connect(s.get(), &KDecoration3::DecorationSettings::spacingChanged, this, &Decoration::updateButtonsGeometryDelayed);
+        connect(s.get(), &KDecoration3::DecorationSettings::decorationButtonsLeftChanged, this, &Decoration::updateButtonsGeometryDelayed);
+        connect(s.get(), &KDecoration3::DecorationSettings::decorationButtonsRightChanged, this, &Decoration::updateButtonsGeometryDelayed);
 
         // full reconfiguration
-        connect(s.get(), &KDecoration2::DecorationSettings::reconfigured, this, &Decoration::reconfigure);
-        connect(s.get(), &KDecoration2::DecorationSettings::reconfigured, SettingsProvider::self(), &SettingsProvider::reconfigure, Qt::UniqueConnection );
-        connect(s.get(), &KDecoration2::DecorationSettings::reconfigured, this, &Decoration::updateButtonsGeometryDelayed);
+        connect(s.get(), &KDecoration3::DecorationSettings::reconfigured, this, &Decoration::reconfigure);
+        connect(s.get(), &KDecoration3::DecorationSettings::reconfigured, SettingsProvider::self(), &SettingsProvider::reconfigure, Qt::UniqueConnection);
+        connect(s.get(), &KDecoration3::DecorationSettings::reconfigured, this, &Decoration::updateButtonsGeometryDelayed);
 
-        connect(c, &KDecoration2::DecoratedClient::adjacentScreenEdgesChanged, this, &Decoration::recalculateBorders);
-        connect(c, &KDecoration2::DecoratedClient::maximizedHorizontallyChanged, this, &Decoration::recalculateBorders);
-        connect(c, &KDecoration2::DecoratedClient::maximizedVerticallyChanged, this, &Decoration::recalculateBorders);
-        connect(c, &KDecoration2::DecoratedClient::shadedChanged, this, &Decoration::recalculateBorders);
-        connect(c, &KDecoration2::DecoratedClient::captionChanged, this,
-            [this]()
-            {
-                // update the caption area
-                update(titleBar());
-            }
-        );
+        connect(c, &KDecoration3::DecoratedWindow::adjacentScreenEdgesChanged, this, &Decoration::recalculateBorders);
+        connect(c, &KDecoration3::DecoratedWindow::maximizedHorizontallyChanged, this, &Decoration::recalculateBorders);
+        connect(c, &KDecoration3::DecoratedWindow::maximizedVerticallyChanged, this, &Decoration::recalculateBorders);
+        connect(c, &KDecoration3::DecoratedWindow::shadedChanged, this, &Decoration::recalculateBorders);
+        connect(c, &KDecoration3::DecoratedWindow::captionChanged, this,
+                [this]()
+                {
+                    // update the caption area
+                    update(titleBar());
+                });
 
-        connect(c, &KDecoration2::DecoratedClient::activeChanged, this, &Decoration::updateAnimationState);
-        connect(c, &KDecoration2::DecoratedClient::activeChanged, this, &Decoration::createShadow);
-        connect(c, &KDecoration2::DecoratedClient::activeChanged, this, &Decoration::updateBlur);
-        connect(c, &KDecoration2::DecoratedClient::widthChanged, this, &Decoration::updateTitleBar);
-        connect(c, &KDecoration2::DecoratedClient::maximizedChanged, this, &Decoration::updateTitleBar);
-        //connect(c, &KDecoration2::DecoratedClient::maximizedChanged, this, &Decoration::setOpaque);
-        connect(c, &KDecoration2::DecoratedClient::sizeChanged, this, &Decoration::updateBlur);
+        connect(c, &KDecoration3::DecoratedWindow::activeChanged, this, &Decoration::updateAnimationState);
+        connect(c, &KDecoration3::DecoratedWindow::activeChanged, this, &Decoration::createShadow);
+        connect(c, &KDecoration3::DecoratedWindow::activeChanged, this, &Decoration::updateBlur);
+        connect(c, &KDecoration3::DecoratedWindow::widthChanged, this, &Decoration::updateTitleBar);
+        connect(c, &KDecoration3::DecoratedWindow::maximizedChanged, this, &Decoration::updateTitleBar);
+        // connect(c, &KDecoration3::DecoratedWindow::maximizedChanged, this, &Decoration::setOpaque);
+        connect(c, &KDecoration3::DecoratedWindow::sizeChanged, this, &Decoration::updateBlur);
 
-        connect(c, &KDecoration2::DecoratedClient::widthChanged, this, &Decoration::updateButtonsGeometry);
-        connect(c, &KDecoration2::DecoratedClient::maximizedChanged, this, &Decoration::updateButtonsGeometry);
-        connect(c, &KDecoration2::DecoratedClient::adjacentScreenEdgesChanged, this, &Decoration::updateButtonsGeometry);
-        connect(c, &KDecoration2::DecoratedClient::shadedChanged, this, &Decoration::updateButtonsGeometry);
+        connect(c, &KDecoration3::DecoratedWindow::widthChanged, this, &Decoration::updateButtonsGeometry);
+        connect(c, &KDecoration3::DecoratedWindow::maximizedChanged, this, &Decoration::updateButtonsGeometry);
+        connect(c, &KDecoration3::DecoratedWindow::adjacentScreenEdgesChanged, this, &Decoration::updateButtonsGeometry);
+        connect(c, &KDecoration3::DecoratedWindow::shadedChanged, this, &Decoration::updateButtonsGeometry);
 
         createButtons();
         createShadow();
@@ -434,76 +445,80 @@ namespace Breeze
     void Decoration::updateTitleBar()
     {
         auto s = settings();
-        auto c = client();
+        auto c = window();
         const bool maximized = isMaximized();
-        const int width =  maximized ? c->width() : c->width() - 2*s->largeSpacing()*Metrics::TitleBar_SideMargin;
-        const int height = maximized ? borderTop() : borderTop() - s->smallSpacing()*Metrics::TitleBar_TopMargin;
-        const int x = maximized ? 0 : s->largeSpacing()*Metrics::TitleBar_SideMargin;
-        const int y = maximized ? 0 : s->smallSpacing()*Metrics::TitleBar_TopMargin;
+        const int width = maximized ? c->width() : c->width() - 2 * s->largeSpacing() * Metrics::TitleBar_SideMargin;
+        const int height = maximized ? borderTop() : borderTop() - s->smallSpacing() * Metrics::TitleBar_TopMargin;
+        const int x = maximized ? 0 : s->largeSpacing() * Metrics::TitleBar_SideMargin;
+        const int y = maximized ? 0 : s->smallSpacing() * Metrics::TitleBar_TopMargin;
         setTitleBar(QRect(x, y, width, height));
     }
 
     //________________________________________________________________
     void Decoration::updateAnimationState()
     {
-        if( m_internalSettings->animationsEnabled() )
+        if (m_internalSettings->animationsEnabled())
         {
 
-            auto c = client();
-            m_animation->setDirection( c->isActive() ? QAbstractAnimation::Forward : QAbstractAnimation::Backward );
-            if( m_animation->state() != QAbstractAnimation::Running ) m_animation->start();
-
-        } else {
+            auto c = window();
+            m_animation->setDirection(c->isActive() ? QAbstractAnimation::Forward : QAbstractAnimation::Backward);
+            if (m_animation->state() != QAbstractAnimation::Running)
+                m_animation->start();
+        }
+        else
+        {
 
             update();
-
         }
     }
 
     //________________________________________________________________
     void Decoration::updateShadow()
     {
-        auto c = client();
+        auto c = window();
 
-        if ( !g_specificShadowsInactiveWindows || c->isActive() )
-          updateActiveShadow();
+        if (!g_specificShadowsInactiveWindows || c->isActive())
+            updateActiveShadow();
         else
-          updateInactiveShadow();
+            updateInactiveShadow();
     }
 
     //________________________________________________________________
-    void Decoration::updateActiveShadow() {
+    void Decoration::updateActiveShadow()
+    {
 
         CompositeShadowParams params;
         params = lookupShadowParams(g_shadowSizeEnum);
 
-        if ( params.isNone() ) {
-          g_sShadow.reset();
-          setShadow(g_sShadow);
-          return;
+        if (params.isNone())
+        {
+            g_sShadow.reset();
+            setShadow(g_sShadow);
+            return;
         }
 
-        auto withOpacity = [](const QColor &color, qreal opacity) -> QColor {
-          QColor c(color);
-          c.setAlphaF(opacity);
-          return c;
+        auto withOpacity = [](const QColor &color, qreal opacity) -> QColor
+        {
+            QColor c(color);
+            c.setAlphaF(opacity);
+            return c;
         };
 
         const auto s = settings();
 
-        const QSize boxSize = BoxShadowRenderer::calculateMinimumBoxSize(2*s->smallSpacing()*params.shadow1.radius)
-        .expandedTo(BoxShadowRenderer::calculateMinimumBoxSize(2*s->smallSpacing()*params.shadow2.radius));
+        const QSize boxSize = BoxShadowRenderer::calculateMinimumBoxSize(2 * s->smallSpacing() * params.shadow1.radius)
+                                  .expandedTo(BoxShadowRenderer::calculateMinimumBoxSize(2 * s->smallSpacing() * params.shadow2.radius));
 
         BoxShadowRenderer shadowRenderer;
-        shadowRenderer.setBorderRadius(0.5*s->smallSpacing()*(m_internalSettings->cornerRadius() + 0.5));
+        shadowRenderer.setBorderRadius(0.5 * s->smallSpacing() * (m_internalSettings->cornerRadius() + 0.5));
         shadowRenderer.setBoxSize(boxSize);
         shadowRenderer.setDevicePixelRatio(1.0); // TODO: Create HiDPI shadows?
 
         const qreal strength = static_cast<qreal>(g_shadowStrength) / 255.0;
         shadowRenderer.addShadow(params.shadow1.offset, params.shadow1.radius,
-            withOpacity(g_shadowColor, params.shadow1.opacity * strength));
+                                 withOpacity(g_shadowColor, params.shadow1.opacity * strength));
         shadowRenderer.addShadow(params.shadow2.offset, params.shadow2.radius,
-            withOpacity(g_shadowColor, params.shadow2.opacity * strength));
+                                 withOpacity(g_shadowColor, params.shadow2.opacity * strength));
 
         QImage shadowTexture = shadowRenderer.render();
 
@@ -528,8 +543,8 @@ namespace Breeze
         painter.setCompositionMode(QPainter::CompositionMode_DestinationOut);
         painter.drawRoundedRect(
             innerRect,
-            0.5*s->smallSpacing()*(m_internalSettings->cornerRadius() + 0.5),
-            0.5*s->smallSpacing()*(m_internalSettings->cornerRadius() + 0.5));
+            0.5 * s->smallSpacing() * (m_internalSettings->cornerRadius() + 0.5),
+            0.5 * s->smallSpacing() * (m_internalSettings->cornerRadius() + 0.5));
 
         // Draw outline.
         // painter.setPen(withOpacity(g_shadowColor, 0.2 * strength));
@@ -542,7 +557,7 @@ namespace Breeze
 
         painter.end();
 
-        g_sShadow = std::make_shared<KDecoration2::DecorationShadow>();
+        g_sShadow = std::make_shared<KDecoration3::DecorationShadow>();
         g_sShadow->setPadding(padding);
         g_sShadow->setInnerShadowRect(QRect(outerRect.center(), QSize(1, 1)));
         g_sShadow->setShadow(shadowTexture);
@@ -551,38 +566,41 @@ namespace Breeze
     }
 
     //________________________________________________________________
-    void Decoration::updateInactiveShadow() {
+    void Decoration::updateInactiveShadow()
+    {
 
         CompositeShadowParams params;
         params = lookupShadowParamsInactiveWindows(g_shadowSizeEnumInactiveWindows);
 
-        if ( params.isNone() ) {
-          g_sShadow.reset();
-          setShadow(g_sShadow);
-          return;
+        if (params.isNone())
+        {
+            g_sShadow.reset();
+            setShadow(g_sShadow);
+            return;
         }
 
-        auto withOpacity = [](const QColor &color, qreal opacity) -> QColor {
-          QColor c(color);
-          c.setAlphaF(opacity);
-          return c;
+        auto withOpacity = [](const QColor &color, qreal opacity) -> QColor
+        {
+            QColor c(color);
+            c.setAlphaF(opacity);
+            return c;
         };
 
         const auto s = settings();
 
-        const QSize boxSize = BoxShadowRenderer::calculateMinimumBoxSize(2*s->smallSpacing()*params.shadow1.radius)
-        .expandedTo(BoxShadowRenderer::calculateMinimumBoxSize(2*s->smallSpacing()*params.shadow2.radius));
+        const QSize boxSize = BoxShadowRenderer::calculateMinimumBoxSize(2 * s->smallSpacing() * params.shadow1.radius)
+                                  .expandedTo(BoxShadowRenderer::calculateMinimumBoxSize(2 * s->smallSpacing() * params.shadow2.radius));
 
         BoxShadowRenderer shadowRenderer;
-        shadowRenderer.setBorderRadius(0.5*s->smallSpacing()*(m_internalSettings->cornerRadius() + 0.5));
+        shadowRenderer.setBorderRadius(0.5 * s->smallSpacing() * (m_internalSettings->cornerRadius() + 0.5));
         shadowRenderer.setBoxSize(boxSize);
         shadowRenderer.setDevicePixelRatio(1.0); // TODO: Create HiDPI shadows?
 
         const qreal strength = static_cast<qreal>(g_shadowStrengthInactiveWindows) / 255.0;
         shadowRenderer.addShadow(params.shadow1.offset, params.shadow1.radius,
-            withOpacity(g_shadowColorInactiveWindows, params.shadow1.opacity * strength));
+                                 withOpacity(g_shadowColorInactiveWindows, params.shadow1.opacity * strength));
         shadowRenderer.addShadow(params.shadow2.offset, params.shadow2.radius,
-            withOpacity(g_shadowColorInactiveWindows, params.shadow2.opacity * strength));
+                                 withOpacity(g_shadowColorInactiveWindows, params.shadow2.opacity * strength));
 
         QImage shadowTexture = shadowRenderer.render();
 
@@ -607,8 +625,8 @@ namespace Breeze
         painter.setCompositionMode(QPainter::CompositionMode_DestinationOut);
         painter.drawRoundedRect(
             innerRect,
-            0.5*s->smallSpacing()*(m_internalSettings->cornerRadius() + 0.5),
-            0.5*s->smallSpacing()*(m_internalSettings->cornerRadius() + 0.5));
+            0.5 * s->smallSpacing() * (m_internalSettings->cornerRadius() + 0.5),
+            0.5 * s->smallSpacing() * (m_internalSettings->cornerRadius() + 0.5));
 
         // Draw outline.
         // painter.setPen(withOpacity(g_shadowColorInactiveWindows, 0.2 * strength));
@@ -621,7 +639,7 @@ namespace Breeze
 
         painter.end();
 
-        g_sShadow = std::make_shared<KDecoration2::DecorationShadow>();
+        g_sShadow = std::make_shared<KDecoration3::DecorationShadow>();
         g_sShadow->setPadding(padding);
         g_sShadow->setInnerShadowRect(QRect(outerRect.center(), QSize(1, 1)));
         g_sShadow->setShadow(shadowTexture);
@@ -632,43 +650,66 @@ namespace Breeze
     //________________________________________________________________
     void Decoration::updateSizeGripVisibility()
     {
-        auto c = client();
-        if( m_sizeGrip )
-        { m_sizeGrip->setVisible( c->isResizeable() && !isMaximized() && !c->isShaded() ); }
+        auto c = window();
+        if (m_sizeGrip)
+        {
+            m_sizeGrip->setVisible(c->isResizeable() && !isMaximized() && !c->isShaded());
+        }
     }
 
     //________________________________________________________________
     int Decoration::borderSize(bool bottom) const
     {
         const int baseSize = settings()->smallSpacing();
-        if( m_internalSettings && (m_internalSettings->mask() & BorderSize ) )
+        if (m_internalSettings && (m_internalSettings->mask() & BorderSize))
         {
-            switch (m_internalSettings->borderSize()) {
-                case InternalSettings::BorderNone: return 0;
-                case InternalSettings::BorderNoSides: return bottom ? qMax(4, baseSize) : 0;
-                default:
-                case InternalSettings::BorderTiny: return 1;
-                case InternalSettings::BorderNormal: return bottom ? qMax(4, baseSize) : baseSize;
-                case InternalSettings::BorderLarge: return baseSize*2;
-                case InternalSettings::BorderVeryLarge: return baseSize*3;
-                case InternalSettings::BorderHuge: return baseSize*4;
-                case InternalSettings::BorderVeryHuge: return baseSize*5;
-                case InternalSettings::BorderOversized: return baseSize*6;
+            switch (m_internalSettings->borderSize())
+            {
+            case InternalSettings::BorderNone:
+                return 0;
+            case InternalSettings::BorderNoSides:
+                return bottom ? qMax(4, baseSize) : 0;
+            default:
+            case InternalSettings::BorderTiny:
+                return 1;
+            case InternalSettings::BorderNormal:
+                return bottom ? qMax(4, baseSize) : baseSize;
+            case InternalSettings::BorderLarge:
+                return baseSize * 2;
+            case InternalSettings::BorderVeryLarge:
+                return baseSize * 3;
+            case InternalSettings::BorderHuge:
+                return baseSize * 4;
+            case InternalSettings::BorderVeryHuge:
+                return baseSize * 5;
+            case InternalSettings::BorderOversized:
+                return baseSize * 6;
             }
+        }
+        else
+        {
 
-        } else {
-
-            switch (settings()->borderSize()) {
-                case KDecoration2::BorderSize::None: return 0;
-                case KDecoration2::BorderSize::NoSides: return bottom ? qMax(4, baseSize) : 0;
-                default:
-                case KDecoration2::BorderSize::Tiny: return 1;
-                case KDecoration2::BorderSize::Normal: return bottom ? qMax(4, baseSize) : baseSize;
-                case KDecoration2::BorderSize::Large: return baseSize*2;
-                case KDecoration2::BorderSize::VeryLarge: return baseSize*3;
-                case KDecoration2::BorderSize::Huge: return baseSize*4;
-                case KDecoration2::BorderSize::VeryHuge: return baseSize*5;
-                case KDecoration2::BorderSize::Oversized: return baseSize*6;
+            switch (settings()->borderSize())
+            {
+            case KDecoration3::BorderSize::None:
+                return 0;
+            case KDecoration3::BorderSize::NoSides:
+                return bottom ? qMax(4, baseSize) : 0;
+            default:
+            case KDecoration3::BorderSize::Tiny:
+                return 1;
+            case KDecoration3::BorderSize::Normal:
+                return bottom ? qMax(4, baseSize) : baseSize;
+            case KDecoration3::BorderSize::Large:
+                return baseSize * 2;
+            case KDecoration3::BorderSize::VeryLarge:
+                return baseSize * 3;
+            case KDecoration3::BorderSize::Huge:
+                return baseSize * 4;
+            case KDecoration3::BorderSize::VeryHuge:
+                return baseSize * 5;
+            case KDecoration3::BorderSize::Oversized:
+                return baseSize * 6;
             }
         }
     }
@@ -677,10 +718,10 @@ namespace Breeze
     void Decoration::reconfigure()
     {
 
-        m_internalSettings = SettingsProvider::self()->internalSettings( this );
+        m_internalSettings = SettingsProvider::self()->internalSettings(this);
 
         // animation
-        m_animation->setDuration( m_internalSettings->animationsDuration() );
+        m_animation->setDuration(m_internalSettings->animationsDuration());
 
         // borders
         recalculateBorders();
@@ -691,37 +732,39 @@ namespace Breeze
         createShadow();
 
         // size grip
-        if( borderSize() <= 1 && m_internalSettings->drawSizeGrip() ) createSizeGrip();
-        else deleteSizeGrip();
-
+        if (borderSize() <= 1 && m_internalSettings->drawSizeGrip())
+            createSizeGrip();
+        else
+            deleteSizeGrip();
     }
 
     //________________________________________________________________
     void Decoration::recalculateBorders()
     {
-        auto c = client();
+        auto c = window();
         auto s = settings();
 
         // left, right and bottom borders
-        const int left   = isLeftEdge() ? 0 : borderSize();
-        const int right  = isRightEdge() ? 0 : borderSize();
+        const int left = isLeftEdge() ? 0 : borderSize();
+        const int right = isRightEdge() ? 0 : borderSize();
         const int bottom = (c->isShaded() || isBottomEdge()) ? 0 : borderSize(true);
 
         int top = 0;
-        if( hideTitleBar() ) top = bottom;
-        else {
+        if (hideTitleBar())
+            top = bottom;
+        else
+        {
 
             QFontMetrics fm(s->font());
-            top += qMax(fm.height(), buttonHeight() );
+            top += qMax(fm.height(), buttonHeight());
 
             // padding below
             // extra pixel is used for the active window outline
             const int baseSize = s->smallSpacing();
-            top += baseSize*Metrics::TitleBar_BottomMargin + m_internalSettings->buttonPadding(); // + 1;
+            top += baseSize * Metrics::TitleBar_BottomMargin + m_internalSettings->buttonPadding(); // + 1;
 
             // padding above
-            top += baseSize*TitleBar_TopMargin + m_internalSettings->buttonPadding();
-
+            top += baseSize * TitleBar_TopMargin + m_internalSettings->buttonPadding();
         }
 
         setBorders(QMargins(left, top, right, bottom));
@@ -730,10 +773,12 @@ namespace Breeze
         const int extSize = s->largeSpacing();
         int extHSides = 0;
         int extVSides = 0;
-        if( borderSize() <= 1 )
+        if (borderSize() <= 1)
         {
-            if( !isMaximizedHorizontally() ) extHSides = extSize;
-            if( !isMaximizedVertically() ) extVSides = extSize;
+            if (!isMaximizedHorizontally())
+                extHSides = extSize;
+            if (!isMaximizedVertically())
+                extVSides = extSize;
         }
 
         setResizeOnlyBorders(QMargins(extHSides, extVSides, extHSides, extVSides));
@@ -742,79 +787,85 @@ namespace Breeze
     //________________________________________________________________
     void Decoration::createButtons()
     {
-        m_leftButtons = new KDecoration2::DecorationButtonGroup(KDecoration2::DecorationButtonGroup::Position::Left, this, &Button::create);
-        m_rightButtons = new KDecoration2::DecorationButtonGroup(KDecoration2::DecorationButtonGroup::Position::Right, this, &Button::create);
+        m_leftButtons = new KDecoration3::DecorationButtonGroup(KDecoration3::DecorationButtonGroup::Position::Left, this, &Button::create);
+        m_rightButtons = new KDecoration3::DecorationButtonGroup(KDecoration3::DecorationButtonGroup::Position::Right, this, &Button::create);
         updateButtonsGeometry();
     }
 
     void Decoration::updateBlur()
     {
         // access client
-        auto c = client();
+        auto c = window();
         Q_ASSERT(c);
 
-        //disable blur if the titlebar is opaque
-        if( (m_internalSettings->opaqueTitleBar() && c->isMaximized() )
-            || ( m_opacity == 100 && this->titleBarColor().alpha() == 255 )
-        ){ //opaque titlebar colours
-            setBlurRegion( QRegion() );
+        // disable blur if the titlebar is opaque
+        if ((m_internalSettings->opaqueTitleBar() && c->isMaximized()) || (m_opacity == 100 && this->titleBarColor().alpha() == 255))
+        { // opaque titlebar colours
+            setBlurRegion(QRegion());
         }
-        else { //transparent titlebar colours
-            calculateWindowAndTitleBarShapes(true); //refreshes m_windowPath
-            setBlurRegion( QRegion( m_windowPath->toFillPolygon().toPolygon()) ) ;
+        else
+        {                                           // transparent titlebar colours
+            calculateWindowAndTitleBarShapes(true); // refreshes m_windowPath
+            setBlurRegion(QRegion(m_windowPath->toFillPolygon().toPolygon()));
         }
     }
 
     void Decoration::calculateWindowAndTitleBarShapes(const bool windowShapeOnly)
     {
-        auto c = client();
+        auto c = window();
         Q_ASSERT(c);
         auto s = settings();
-        
-        if( !windowShapeOnly || c->isShaded() )
+
+        if (!windowShapeOnly || c->isShaded())
         {
-            //set titleBar geometry and path
+            // set titleBar geometry and path
             m_titleRect = QRect(QPoint(0, 0), QSize(size().width(), borderTop()));
-            m_titleBarPath->clear(); //clear the path for subsequent calls to this function
-            if( isMaximized() || !s->isAlphaChannelSupported() )
+            m_titleBarPath->clear(); // clear the path for subsequent calls to this function
+            if (isMaximized() || !s->isAlphaChannelSupported())
             {
                 m_titleBarPath->addRect(m_titleRect);
-
-            } else if( c->isShaded() ) {
-                m_titleBarPath->addRoundedRect(m_titleRect, 0.5*s->smallSpacing()*m_internalSettings->cornerRadius(), 0.5*s->smallSpacing()*m_internalSettings->cornerRadius());
-
-            } else {
+            }
+            else if (c->isShaded())
+            {
+                m_titleBarPath->addRoundedRect(m_titleRect, 0.5 * s->smallSpacing() * m_internalSettings->cornerRadius(), 0.5 * s->smallSpacing() * m_internalSettings->cornerRadius());
+            }
+            else
+            {
                 QPainterPath clipRect;
                 clipRect.addRect(m_titleRect);
 
                 // the rect is made a little bit larger to be able to clip away the rounded corners at the bottom and sides
                 m_titleBarPath->addRoundedRect(m_titleRect.adjusted(
-                    isLeftEdge() ? -0.5*s->smallSpacing()*m_internalSettings->cornerRadius():0,
-                    isTopEdge() ? -0.5*s->smallSpacing()*m_internalSettings->cornerRadius():0,
-                    isRightEdge() ? 0.5*s->smallSpacing()*m_internalSettings->cornerRadius():0,
-                    0.5*s->smallSpacing()*m_internalSettings->cornerRadius()),
-                    0.5*s->smallSpacing()*m_internalSettings->cornerRadius(), 0.5*s->smallSpacing()*m_internalSettings->cornerRadius());
+                                                   isLeftEdge() ? -0.5 * s->smallSpacing() * m_internalSettings->cornerRadius() : 0,
+                                                   isTopEdge() ? -0.5 * s->smallSpacing() * m_internalSettings->cornerRadius() : 0,
+                                                   isRightEdge() ? 0.5 * s->smallSpacing() * m_internalSettings->cornerRadius() : 0,
+                                                   0.5 * s->smallSpacing() * m_internalSettings->cornerRadius()),
+                                               0.5 * s->smallSpacing() * m_internalSettings->cornerRadius(), 0.5 * s->smallSpacing() * m_internalSettings->cornerRadius());
 
                 *m_titleBarPath = m_titleBarPath->intersected(clipRect);
             }
         }
-        
-        //set windowPath
-        m_windowPath->clear(); //clear the path for subsequent calls to this function
-        if( !c->isShaded() )
+
+        // set windowPath
+        m_windowPath->clear(); // clear the path for subsequent calls to this function
+        if (!c->isShaded())
         {
-            if( s->isAlphaChannelSupported() && !isMaximized() ) m_windowPath->addRoundedRect(rect(), 0.5*s->smallSpacing()*m_internalSettings->cornerRadius(), 0.5*s->smallSpacing()*m_internalSettings->cornerRadius());
-            else m_windowPath->addRect( rect() );
-            
-        } else {
+            if (s->isAlphaChannelSupported() && !isMaximized())
+                m_windowPath->addRoundedRect(rect(), 0.5 * s->smallSpacing() * m_internalSettings->cornerRadius(), 0.5 * s->smallSpacing() * m_internalSettings->cornerRadius());
+            else
+                m_windowPath->addRect(rect());
+        }
+        else
+        {
             *m_windowPath = *m_titleBarPath;
         }
-        
     }
 
     //________________________________________________________________
     void Decoration::updateButtonsGeometryDelayed()
-    { QTimer::singleShot( 0, this, &Decoration::updateButtonsGeometry ); }
+    {
+        QTimer::singleShot(0, this, &Decoration::updateButtonsGeometry);
+    }
 
     //________________________________________________________________
     void Decoration::updateButtonsGeometry()
@@ -823,95 +874,98 @@ namespace Breeze
 
         // adjust button position
         const int bWidth = buttonHeight();
-        const int bHeight = bWidth + (isTopEdge() ? s->smallSpacing()*Metrics::TitleBar_TopMargin:0);
-        const int verticalOffset = (isTopEdge() ? s->smallSpacing()*Metrics::TitleBar_TopMargin:0) + (captionHeight()-buttonHeight())/2;
-        foreach( const QPointer<KDecoration2::DecorationButton>& button, m_leftButtons->buttons() + m_rightButtons->buttons() )
+        const int bHeight = bWidth + (isTopEdge() ? s->smallSpacing() * Metrics::TitleBar_TopMargin : 0);
+        const int verticalOffset = (isTopEdge() ? s->smallSpacing() * Metrics::TitleBar_TopMargin : 0) + (captionHeight() - buttonHeight()) / 2;
+        foreach (const QPointer<KDecoration3::DecorationButton> &button, m_leftButtons->buttons() + m_rightButtons->buttons())
         {
-            button->setGeometry( QRectF( QPoint( 0, 0 ), QSizeF( bWidth, bHeight ) ) );
-            static_cast<Button*>( button.data() )->setIconSize( QSize( bWidth, bWidth ) );
+            button->setGeometry(QRectF(QPoint(0, 0), QSizeF(bWidth, bHeight)));
+            static_cast<Button *>(button.data())->setIconSize(QSize(bWidth, bWidth));
         }
 
         // padding
-        const int vPadding = isTopEdge() ? 0 : s->smallSpacing()*Metrics::TitleBar_TopMargin;
-        const int hPadding = s->smallSpacing()*Metrics::TitleBar_SideMargin;
-        const int hMargin = 0.5*s->smallSpacing()*m_internalSettings->buttonPadding() + 0.5*s->smallSpacing()*m_internalSettings->hOffset();
+        const int vPadding = isTopEdge() ? 0 : s->smallSpacing() * Metrics::TitleBar_TopMargin;
+        const int hPadding = s->smallSpacing() * Metrics::TitleBar_SideMargin;
+        const int hMargin = 0.5 * s->smallSpacing() * m_internalSettings->buttonPadding() + 0.5 * s->smallSpacing() * m_internalSettings->hOffset();
 
         // left buttons
-        if( !m_leftButtons->buttons().isEmpty() )
+        if (!m_leftButtons->buttons().isEmpty())
         {
 
             // spacing (use our own spacing instead of s->smallSpacing()*Metrics::TitleBar_ButtonSpacing)
-            m_leftButtons->setSpacing(0.5*s->smallSpacing()*m_internalSettings->buttonSpacing());
+            m_leftButtons->setSpacing(0.5 * s->smallSpacing() * m_internalSettings->buttonSpacing());
 
-            if( isLeftEdge() )
+            if (isLeftEdge())
             {
                 // add offsets on the side buttons, to preserve padding, but satisfy Fitts law
-                auto button = static_cast<Button*>( m_leftButtons->buttons().front() );
-                button->setGeometry( QRectF( QPoint( 0, 0 ), QSizeF( bWidth + hPadding, bHeight ) ) );
-                button->setFlag( Button::FlagFirstInList );
+                auto button = static_cast<Button *>(m_leftButtons->buttons().front());
+                button->setGeometry(QRectF(QPoint(0, 0), QSizeF(bWidth + hPadding, bHeight)));
+                button->setFlag(Button::FlagFirstInList);
 
                 m_leftButtons->setPos(QPointF(hMargin, verticalOffset + vPadding));
-
-            } else m_leftButtons->setPos(QPointF(hMargin + borderLeft(), verticalOffset + vPadding));
-
+            }
+            else
+                m_leftButtons->setPos(QPointF(hMargin + borderLeft(), verticalOffset + vPadding));
         }
 
         // right buttons
-        if( !m_rightButtons->buttons().isEmpty() )
+        if (!m_rightButtons->buttons().isEmpty())
         {
 
             // spacing (use our own spacing instead of s->smallSpacing()*Metrics::TitleBar_ButtonSpacing)
-            m_rightButtons->setSpacing(0.5*s->smallSpacing()*m_internalSettings->buttonSpacing());
+            m_rightButtons->setSpacing(0.5 * s->smallSpacing() * m_internalSettings->buttonSpacing());
 
-            if( isRightEdge() )
+            if (isRightEdge())
             {
 
-                auto button = static_cast<Button*>( m_rightButtons->buttons().back() );
-                button->setGeometry( QRectF( QPoint( 0, 0 ), QSizeF( bWidth + hPadding, bHeight ) ) );
-                button->setFlag( Button::FlagLastInList );
+                auto button = static_cast<Button *>(m_rightButtons->buttons().back());
+                button->setGeometry(QRectF(QPoint(0, 0), QSizeF(bWidth + hPadding, bHeight)));
+                button->setFlag(Button::FlagLastInList);
 
                 m_rightButtons->setPos(QPointF(size().width() - m_rightButtons->geometry().width() - hMargin, verticalOffset + vPadding));
-
-            } else m_rightButtons->setPos(QPointF(size().width() - m_rightButtons->geometry().width() - hMargin - borderRight(), verticalOffset + vPadding));
-
+            }
+            else
+                m_rightButtons->setPos(QPointF(size().width() - m_rightButtons->geometry().width() - hMargin - borderRight(), verticalOffset + vPadding));
         }
 
         update();
-
     }
 
     //________________________________________________________________
-    void Decoration::paint(QPainter *painter, const QRect &repaintRegion)
+    void Decoration::paint(QPainter *painter, const QRectF &repaintRegion)
     {
         // TODO: optimize based on repaintRegion
-        auto c = client();
+        auto c = window();
         auto s = settings();
 
         QColor titleBarColor = this->titleBarColor();
 
         // paint background
-        if( !c->isShaded() )
+        if (!c->isShaded())
         {
             painter->fillRect(rect(), Qt::transparent);
             painter->save();
             painter->setRenderHint(QPainter::Antialiasing);
-            painter->setBrush( titleBarColor );
+            painter->setBrush(titleBarColor);
 
             // clip away the top part
-            if( !hideTitleBar() ) painter->setClipRect(0, borderTop(), size().width(), size().height() - borderTop(), Qt::IntersectClip);
+            if (!hideTitleBar())
+                painter->setClipRect(0, borderTop(), size().width(), size().height() - borderTop(), Qt::IntersectClip);
 
             // When no borders set, outline will be drawn by shader
             QPen border_pen1;
-            if(borderSize() == 0)
-                border_pen1 = QPen( titleBarColor );
+            if (borderSize() == 0)
+                border_pen1 = QPen(titleBarColor);
             else
-                border_pen1 = QPen( titleBarColor.darker( 125 ) );
+                border_pen1 = QPen(titleBarColor.darker(125));
 
             painter->setPen(border_pen1);
-            if( s->isAlphaChannelSupported() ) {
-                painter->drawRoundedRect(rect(), 0.5*s->smallSpacing()*m_internalSettings->cornerRadius(), 0.5*s->smallSpacing()*m_internalSettings->cornerRadius());
-            } else {
-                painter->drawRect( rect() );
+            if (s->isAlphaChannelSupported())
+            {
+                painter->drawRoundedRect(rect(), 0.5 * s->smallSpacing() * m_internalSettings->cornerRadius(), 0.5 * s->smallSpacing() * m_internalSettings->cornerRadius());
+            }
+            else
+            {
+                painter->drawRect(rect());
             }
 
             painter->restore();
@@ -919,96 +973,99 @@ namespace Breeze
 
         paintTitleBar(painter, repaintRegion);
 
-        if ( hasBorders() )
+        if (hasBorders())
         {
             painter->save();
             // painter->setRenderHint(QPainter::Antialiasing, false);
-            painter->setBrush( Qt::NoBrush );
+            painter->setBrush(Qt::NoBrush);
 
-            QPen border_pen1( titleBarColor.darker( 125 ) );
+            QPen border_pen1(titleBarColor.darker(125));
             painter->setPen(border_pen1);
-            if( s->isAlphaChannelSupported() )
-              painter->drawRoundedRect(rect(), 0.5*s->smallSpacing()*m_internalSettings->cornerRadius(), 0.5*s->smallSpacing()*m_internalSettings->cornerRadius());
+            if (s->isAlphaChannelSupported())
+                painter->drawRoundedRect(rect(), 0.5 * s->smallSpacing() * m_internalSettings->cornerRadius(), 0.5 * s->smallSpacing() * m_internalSettings->cornerRadius());
             else
-              painter->drawRect( rect() );
+                painter->drawRect(rect());
 
             painter->restore();
         }
-
     }
 
     //________________________________________________________________
-    void Decoration::paintTitleBar(QPainter *painter, const QRect &repaintRegion)
+    void Decoration::paintTitleBar(QPainter *painter, const QRectF &repaintRegion)
     {
-        const QRect titleRect(QPoint(0, 0), QSize(size().width(), borderTop()));
-        if ( !titleRect.intersects(repaintRegion) ) return;
+        const QRectF titleRect(QPoint(0, 0), QSize(size().width(), borderTop()));
+        if (!titleRect.intersects(repaintRegion))
+            return;
 
-        auto c = client();
-        QColor outlineColor( this->outlineColor() );
+        auto c = window();
+        QColor outlineColor(this->outlineColor());
         QColor titleBarColor = this->titleBarColor();
 
         painter->save();
         painter->setPen(Qt::NoPen);
 
         // render a linear gradient on title area
-        if ( drawBackgroundGradient() )
+        if (drawBackgroundGradient())
         {
-            QLinearGradient gradient( 0, 0, 0, titleRect.height() );
+            QLinearGradient gradient(0, 0, 0, titleRect.height());
             int b = m_internalSettings->gradientOverride() > -1 ? m_internalSettings->gradientOverride() : m_internalSettings->backgroundGradientIntensity();
-            if ( !c->isActive() )
-                 b *= 0.5;
-            b =  qBound(0, b, 100);
-            gradient.setColorAt(0.0, titleBarColor.lighter( 100 + b));
+            if (!c->isActive())
+                b *= 0.5;
+            b = qBound(0, b, 100);
+            gradient.setColorAt(0.0, titleBarColor.lighter(100 + b));
             gradient.setColorAt(1.0, titleBarColor);
             painter->setBrush(gradient);
         }
         else
-            painter->setBrush( titleBarColor );
+            painter->setBrush(titleBarColor);
 
         auto s = settings();
-        if( !s->isAlphaChannelSupported() )
+        if (!s->isAlphaChannelSupported())
             painter->drawRect(titleRect);
-        else if ( !hasBorders() ) {
+        else if (!hasBorders())
+        {
             painter->setClipRect(titleRect, Qt::IntersectClip);
             // the rect is made a little bit larger to be able to clip away the rounded corners at the bottom and sides
-            QRect adjustetTitleRect = titleRect.adjusted(
-                isLeftEdge() ? -m_internalSettings->cornerRadius():0,
-                isTopEdge() ? -m_internalSettings->cornerRadius():0,
-                isRightEdge() ? m_internalSettings->cornerRadius():0,
+            QRectF adjustetTitleRect = titleRect.adjusted(
+                isLeftEdge() ? -m_internalSettings->cornerRadius() : 0,
+                isTopEdge() ? -m_internalSettings->cornerRadius() : 0,
+                isRightEdge() ? m_internalSettings->cornerRadius() : 0,
                 m_internalSettings->cornerRadius());
 
             painter->drawRoundedRect(adjustetTitleRect, m_internalSettings->cornerRadius(), m_internalSettings->cornerRadius());
         }
-        else {
+        else
+        {
             painter->drawRoundedRect(titleRect, m_internalSettings->cornerRadius(), m_internalSettings->cornerRadius());
         }
 
-        if( !c->isShaded() && !hideTitleBar() && outlineColor.isValid() )
+        if (!c->isShaded() && !hideTitleBar() && outlineColor.isValid())
         {
             // outline
-            painter->setRenderHint( QPainter::Antialiasing, false );
-            painter->setBrush( Qt::NoBrush );
+            painter->setRenderHint(QPainter::Antialiasing, false);
+            painter->setBrush(Qt::NoBrush);
             QPen pen(outlineColor);
-            pen.setWidth( 1 );
-            painter->setPen( pen );
-            painter->drawLine( titleRect.bottomLeft() + QPoint(borderSize(), 0), titleRect.bottomRight() - QPoint(borderSize(), 0) );
+            pen.setWidth(1);
+            painter->setPen(pen);
+            painter->drawLine(titleRect.bottomLeft() + QPoint(borderSize(), 0), titleRect.bottomRight() - QPoint(borderSize(), 0));
         }
 
         painter->restore();
 
-        if( !hideTitleBar() ) {
-          // draw all buttons
-          m_leftButtons->paint(painter, repaintRegion);
-          m_rightButtons->paint(painter, repaintRegion);
+        if (!hideTitleBar())
+        {
+            // draw all buttons
+            m_leftButtons->paint(painter, repaintRegion);
+            m_rightButtons->paint(painter, repaintRegion);
 
-          // draw caption
+            // draw caption
 
-          painter->setFont(s->font());
-          painter->setPen( fontColor() );
+            painter->setFont(s->font());
+            painter->setPen(fontColor());
 
-          const auto cR = captionRect();
-          const QString caption = painter->fontMetrics().elidedText(c->caption(), Qt::ElideMiddle, cR.first.width());
-          painter->drawText(cR.first, cR.second | Qt::TextSingleLine, caption);
+            const auto cR = captionRect();
+            const QString caption = painter->fontMetrics().elidedText(c->caption(), Qt::ElideMiddle, cR.first.width());
+            painter->drawText(cR.first, cR.second | Qt::TextSingleLine, caption);
         }
     }
 
@@ -1016,81 +1073,85 @@ namespace Breeze
     int Decoration::buttonHeight() const
     {
         const int baseSize = settings()->gridUnit();
-        switch( m_internalSettings->buttonSize() )
+        switch (m_internalSettings->buttonSize())
         {
-            case InternalSettings::ButtonTiny: return baseSize;
-            case InternalSettings::ButtonSmall: return baseSize*1.5;
-            default:
-            case InternalSettings::ButtonDefault: return baseSize*2;
-            case InternalSettings::ButtonLarge: return baseSize*2.5;
-            case InternalSettings::ButtonVeryLarge: return baseSize*3.5;
+        case InternalSettings::ButtonTiny:
+            return baseSize;
+        case InternalSettings::ButtonSmall:
+            return baseSize * 1.5;
+        default:
+        case InternalSettings::ButtonDefault:
+            return baseSize * 2;
+        case InternalSettings::ButtonLarge:
+            return baseSize * 2.5;
+        case InternalSettings::ButtonVeryLarge:
+            return baseSize * 3.5;
         }
-
     }
 
     //________________________________________________________________
     int Decoration::captionHeight() const
-    { return hideTitleBar() ? borderTop() : borderTop() - settings()->smallSpacing()*(Metrics::TitleBar_BottomMargin + Metrics::TitleBar_TopMargin ); }
+    {
+        return hideTitleBar() ? borderTop() : borderTop() - settings()->smallSpacing() * (Metrics::TitleBar_BottomMargin + Metrics::TitleBar_TopMargin);
+    }
 
     //________________________________________________________________
-    QPair<QRect,Qt::Alignment> Decoration::captionRect() const
+    QPair<QRect, Qt::Alignment> Decoration::captionRect() const
     {
-        if( hideTitleBar() ) return qMakePair( QRect(), Qt::AlignCenter );
-        else {
+        if (hideTitleBar())
+            return qMakePair(QRect(), Qt::AlignCenter);
+        else
+        {
 
             auto s = settings();
-            auto c = client();
-            const int leftOffset = m_leftButtons->buttons().isEmpty() ?
-                Metrics::TitleBar_SideMargin*settings()->smallSpacing() + 0.5*s->smallSpacing()*m_internalSettings->buttonPadding() + 0.5*s->smallSpacing()*m_internalSettings->hOffset() :
-                m_leftButtons->geometry().x() + m_leftButtons->geometry().width() + Metrics::TitleBar_SideMargin*settings()->smallSpacing() + 0.5*s->smallSpacing()*m_internalSettings->buttonPadding() ;
+            auto c = window();
+            const int leftOffset = m_leftButtons->buttons().isEmpty() ? Metrics::TitleBar_SideMargin * settings()->smallSpacing() + 0.5 * s->smallSpacing() * m_internalSettings->buttonPadding() + 0.5 * s->smallSpacing() * m_internalSettings->hOffset() : m_leftButtons->geometry().x() + m_leftButtons->geometry().width() + Metrics::TitleBar_SideMargin * settings()->smallSpacing() + 0.5 * s->smallSpacing() * m_internalSettings->buttonPadding();
 
-            const int rightOffset = m_rightButtons->buttons().isEmpty() ?
-                Metrics::TitleBar_SideMargin*settings()->smallSpacing() + 0.5*s->smallSpacing()*m_internalSettings->buttonPadding() + 0.5*s->smallSpacing()*m_internalSettings->hOffset() :
-                size().width() - m_rightButtons->geometry().x() + Metrics::TitleBar_SideMargin*settings()->smallSpacing() + 0.5*s->smallSpacing()*m_internalSettings->buttonPadding() ;
+            const int rightOffset = m_rightButtons->buttons().isEmpty() ? Metrics::TitleBar_SideMargin * settings()->smallSpacing() + 0.5 * s->smallSpacing() * m_internalSettings->buttonPadding() + 0.5 * s->smallSpacing() * m_internalSettings->hOffset() : size().width() - m_rightButtons->geometry().x() + Metrics::TitleBar_SideMargin * settings()->smallSpacing() + 0.5 * s->smallSpacing() * m_internalSettings->buttonPadding();
 
-            const int yOffset = settings()->smallSpacing()*Metrics::TitleBar_TopMargin;
-            const QRect maxRect( leftOffset, yOffset, size().width() - leftOffset - rightOffset, captionHeight() );
+            const int yOffset = settings()->smallSpacing() * Metrics::TitleBar_TopMargin;
+            const QRect maxRect(leftOffset, yOffset, size().width() - leftOffset - rightOffset, captionHeight());
 
-            switch( m_internalSettings->titleAlignment() )
+            switch (m_internalSettings->titleAlignment())
             {
-                case InternalSettings::AlignLeft:
-                return qMakePair( maxRect, Qt::AlignVCenter|Qt::AlignLeft );
+            case InternalSettings::AlignLeft:
+                return qMakePair(maxRect, Qt::AlignVCenter | Qt::AlignLeft);
 
-                case InternalSettings::AlignRight:
-                return qMakePair( maxRect, Qt::AlignVCenter|Qt::AlignRight );
+            case InternalSettings::AlignRight:
+                return qMakePair(maxRect, Qt::AlignVCenter | Qt::AlignRight);
 
-                case InternalSettings::AlignCenter:
-                return qMakePair( maxRect, Qt::AlignCenter );
+            case InternalSettings::AlignCenter:
+                return qMakePair(maxRect, Qt::AlignCenter);
 
-                default:
-                case InternalSettings::AlignCenterFullWidth:
-                {
+            default:
+            case InternalSettings::AlignCenterFullWidth:
+            {
 
-                    // full caption rect
-                    const QRect fullRect = QRect( 0, yOffset, size().width(), captionHeight() );
-                    QRect boundingRect( settings()->fontMetrics().boundingRect( c->caption()).toRect() );
+                // full caption rect
+                const QRect fullRect = QRect(0, yOffset, size().width(), captionHeight());
+                QRect boundingRect(settings()->fontMetrics().boundingRect(c->caption()).toRect());
 
-                    // text bounding rect
-                    boundingRect.setTop( yOffset );
-                    boundingRect.setHeight( captionHeight() );
-                    boundingRect.moveLeft( ( size().width() - boundingRect.width() )/2 );
+                // text bounding rect
+                boundingRect.setTop(yOffset);
+                boundingRect.setHeight(captionHeight());
+                boundingRect.moveLeft((size().width() - boundingRect.width()) / 2);
 
-                    if( boundingRect.left() < leftOffset ) return qMakePair( maxRect, Qt::AlignVCenter|Qt::AlignLeft );
-                    else if( boundingRect.right() > size().width() - rightOffset ) return qMakePair( maxRect, Qt::AlignVCenter|Qt::AlignRight );
-                    else return qMakePair(fullRect, Qt::AlignCenter);
-
-                }
-
+                if (boundingRect.left() < leftOffset)
+                    return qMakePair(maxRect, Qt::AlignVCenter | Qt::AlignLeft);
+                else if (boundingRect.right() > size().width() - rightOffset)
+                    return qMakePair(maxRect, Qt::AlignVCenter | Qt::AlignRight);
+                else
+                    return qMakePair(fullRect, Qt::AlignCenter);
             }
-
+            }
         }
-
     }
 
     //________________________________________________________________
     void Decoration::createShadow()
     {
-        if ( !g_sShadow ) {
+        if (!g_sShadow)
+        {
             g_shadowSizeEnum = m_internalSettings->shadowSize();
             g_shadowStrength = m_internalSettings->shadowStrength();
             g_shadowColor = m_internalSettings->shadowColor();
@@ -1101,19 +1162,16 @@ namespace Breeze
 
             updateShadow();
         }
-        else if ( g_shadowSizeEnum != m_internalSettings->shadowSize()
-                  || g_shadowStrength != m_internalSettings->shadowStrength()
-                  || g_shadowColor != m_internalSettings->shadowColor() ) {
+        else if (g_shadowSizeEnum != m_internalSettings->shadowSize() || g_shadowStrength != m_internalSettings->shadowStrength() || g_shadowColor != m_internalSettings->shadowColor())
+        {
             g_shadowSizeEnum = m_internalSettings->shadowSize();
             g_shadowStrength = m_internalSettings->shadowStrength();
             g_shadowColor = m_internalSettings->shadowColor();
 
             updateActiveShadow();
         }
-        else if ( g_specificShadowsInactiveWindows != m_internalSettings->specificShadowsInactiveWindows()
-                  || g_shadowSizeEnumInactiveWindows != m_internalSettings->shadowSizeInactiveWindows()
-                  || g_shadowStrengthInactiveWindows != m_internalSettings->shadowStrengthInactiveWindows()
-                  || g_shadowColorInactiveWindows != m_internalSettings->shadowColorInactiveWindows() ) {
+        else if (g_specificShadowsInactiveWindows != m_internalSettings->specificShadowsInactiveWindows() || g_shadowSizeEnumInactiveWindows != m_internalSettings->shadowSizeInactiveWindows() || g_shadowStrengthInactiveWindows != m_internalSettings->shadowStrengthInactiveWindows() || g_shadowColorInactiveWindows != m_internalSettings->shadowColorInactiveWindows())
+        {
             g_specificShadowsInactiveWindows = m_internalSettings->specificShadowsInactiveWindows();
             g_shadowSizeEnumInactiveWindows = m_internalSettings->shadowSizeInactiveWindows();
             g_shadowStrengthInactiveWindows = m_internalSettings->shadowStrengthInactiveWindows();
@@ -1122,7 +1180,7 @@ namespace Breeze
             updateInactiveShadow();
         }
         else
-          updateShadow();
+            updateShadow();
     }
 
     //_________________________________________________________________
@@ -1130,30 +1188,32 @@ namespace Breeze
     {
 
         // do nothing if size grip already exist
-        if( m_sizeGrip ) return;
+        if (m_sizeGrip)
+            return;
 
-        #if BREEZE_HAVE_X11
-        if( !QX11Info::isPlatformX11() ) return;
+#if BREEZE_HAVE_X11
+        if (!QX11Info::isPlatformX11())
+            return;
 
         // access client
-        auto c = client();
-        if( !c ) return;
-
-        if( c->windowId() != 0 )
-        {
-            m_sizeGrip = new SizeGrip( this );
-            connect( c, &KDecoration2::DecoratedClient::maximizedChanged, this, &Decoration::updateSizeGripVisibility );
-            connect( c, &KDecoration2::DecoratedClient::shadedChanged, this, &Decoration::updateSizeGripVisibility );
-            connect( c, &KDecoration2::DecoratedClient::resizeableChanged, this, &Decoration::updateSizeGripVisibility );
-        }
-        #endif
-
+        auto c = window();
+        if (!c)
+            return;
+        //  Commenting out this condition as this property has been dropped since plasma 6.3.
+        // if (c->windowId() != 0)
+        // {
+            m_sizeGrip = new SizeGrip(this);
+            connect(c, &KDecoration3::DecoratedWindow::maximizedChanged, this, &Decoration::updateSizeGripVisibility);
+            connect(c, &KDecoration3::DecoratedWindow::shadedChanged, this, &Decoration::updateSizeGripVisibility);
+            connect(c, &KDecoration3::DecoratedWindow::resizeableChanged, this, &Decoration::updateSizeGripVisibility);
+        // }
+#endif
     }
 
     //_________________________________________________________________
     void Decoration::deleteSizeGrip()
     {
-        if( m_sizeGrip )
+        if (m_sizeGrip)
         {
             m_sizeGrip->deleteLater();
             m_sizeGrip = nullptr;
@@ -1161,6 +1221,5 @@ namespace Breeze
     }
 
 } // namespace
-
 
 #include "breezedecoration.moc"

--- a/breezedecoration.cpp
+++ b/breezedecoration.cpp
@@ -512,7 +512,6 @@ namespace Breeze
         BoxShadowRenderer shadowRenderer;
         shadowRenderer.setBorderRadius(0.5 * s->smallSpacing() * (m_internalSettings->cornerRadius() + 0.5));
         shadowRenderer.setBoxSize(boxSize);
-        
 
         const qreal strength = static_cast<qreal>(g_shadowStrength) / 255.0;
         shadowRenderer.addShadow(params.shadow1.offset, params.shadow1.radius,
@@ -594,7 +593,6 @@ namespace Breeze
         BoxShadowRenderer shadowRenderer;
         shadowRenderer.setBorderRadius(0.5 * s->smallSpacing() * (m_internalSettings->cornerRadius() + 0.5));
         shadowRenderer.setBoxSize(boxSize);
-        
 
         const qreal strength = static_cast<qreal>(g_shadowStrengthInactiveWindows) / 255.0;
         shadowRenderer.addShadow(params.shadow1.offset, params.shadow1.radius,
@@ -789,7 +787,7 @@ namespace Breeze
     {
         m_leftButtons = new KDecoration3::DecorationButtonGroup(KDecoration3::DecorationButtonGroup::Position::Left, this, &Button::create);
         m_rightButtons = new KDecoration3::DecorationButtonGroup(KDecoration3::DecorationButtonGroup::Position::Right, this, &Button::create);
-        updateButtonsGeometry();
+        updateButtonsGeometryDelayed(); // Calling delayed function because borderTop() is signaling 0 initially.
     }
 
     void Decoration::updateBlur()
@@ -1092,7 +1090,14 @@ namespace Breeze
     //________________________________________________________________
     int Decoration::captionHeight() const
     {
-        return hideTitleBar() ? borderTop() : borderTop() - settings()->smallSpacing() * (Metrics::TitleBar_BottomMargin + Metrics::TitleBar_TopMargin);
+        int border = borderTop();
+        // set border a minimum value if it is 0,
+        // to avoid buttons being overflowed 
+        if (border < settings()->smallSpacing() * (Metrics::TitleBar_BottomMargin + Metrics::TitleBar_TopMargin))
+        {
+            border = settings()->smallSpacing() * (Metrics::TitleBar_BottomMargin + Metrics::TitleBar_TopMargin);
+        }
+        return hideTitleBar() ? border : border - settings()->smallSpacing() * (Metrics::TitleBar_BottomMargin + Metrics::TitleBar_TopMargin);
     }
 
     //________________________________________________________________
@@ -1202,10 +1207,10 @@ namespace Breeze
         //  Commenting out this condition as this property has been dropped since plasma 6.3.
         // if (c->windowId() != 0)
         // {
-            m_sizeGrip = new SizeGrip(this);
-            connect(c, &KDecoration3::DecoratedWindow::maximizedChanged, this, &Decoration::updateSizeGripVisibility);
-            connect(c, &KDecoration3::DecoratedWindow::shadedChanged, this, &Decoration::updateSizeGripVisibility);
-            connect(c, &KDecoration3::DecoratedWindow::resizeableChanged, this, &Decoration::updateSizeGripVisibility);
+        m_sizeGrip = new SizeGrip(this);
+        connect(c, &KDecoration3::DecoratedWindow::maximizedChanged, this, &Decoration::updateSizeGripVisibility);
+        connect(c, &KDecoration3::DecoratedWindow::shadedChanged, this, &Decoration::updateSizeGripVisibility);
+        connect(c, &KDecoration3::DecoratedWindow::resizeableChanged, this, &Decoration::updateSizeGripVisibility);
         // }
 #endif
     }

--- a/breezedecoration.h
+++ b/breezedecoration.h
@@ -25,9 +25,9 @@
 #include "breeze.h"
 #include "breezesettings.h"
 
-#include <KDecoration2/Decoration>
-#include <KDecoration2/DecoratedClient>
-#include <KDecoration2/DecorationSettings>
+#include <KDecoration3/Decoration>
+#include <KDecoration3/DecoratedWindow>
+#include <KDecoration3/DecorationSettings>
 
 #include <QPalette>
 #include <QVariant>
@@ -36,7 +36,7 @@
 
 class QVariantAnimation;
 
-namespace KDecoration2
+namespace KDecoration3
 {
     class DecorationButton;
     class DecorationButtonGroup;
@@ -46,7 +46,7 @@ namespace Breeze
 {
     class SizeGrip;
     class Button;
-    class Decoration : public KDecoration2::Decoration
+    class Decoration : public KDecoration3::Decoration
     {
         Q_OBJECT
 
@@ -59,7 +59,7 @@ namespace Breeze
         virtual ~Decoration();
 
         //* paint
-        void paint(QPainter *painter, const QRect &repaintRegion) override;
+        void paint(QPainter *painter, const QRectF &repaintRegion) override;
 
         //* internal settings
         InternalSettingsPtr internalSettings() const
@@ -143,7 +143,7 @@ namespace Breeze
         QPair<QRect,Qt::Alignment> captionRect() const;
 
         void createButtons();
-        void paintTitleBar(QPainter *painter, const QRect &repaintRegion);
+        void paintTitleBar(QPainter *painter, const QRectF &repaintRegion);
         void updateShadow();
         void updateActiveShadow();
         void updateInactiveShadow();
@@ -166,8 +166,8 @@ namespace Breeze
         //@}
 
         InternalSettingsPtr m_internalSettings;
-        KDecoration2::DecorationButtonGroup *m_leftButtons = nullptr;
-        KDecoration2::DecorationButtonGroup *m_rightButtons = nullptr;
+        KDecoration3::DecorationButtonGroup *m_leftButtons = nullptr;
+        KDecoration3::DecorationButtonGroup *m_rightButtons = nullptr;
 
         //* size grip widget
         SizeGrip *m_sizeGrip = nullptr;
@@ -190,44 +190,44 @@ namespace Breeze
     bool Decoration::hasBorders() const
     {
         if( m_internalSettings && m_internalSettings->mask() & BorderSize ) return m_internalSettings->borderSize() > InternalSettings::BorderNoSides;
-        else return settings()->borderSize() > KDecoration2::BorderSize::NoSides;
+        else return settings()->borderSize() > KDecoration3::BorderSize::NoSides;
     }
 
     bool Decoration::hasNoBorders() const
     {
         if( m_internalSettings && m_internalSettings->mask() & BorderSize ) return m_internalSettings->borderSize() == InternalSettings::BorderNone;
-        else return settings()->borderSize() == KDecoration2::BorderSize::None;
+        else return settings()->borderSize() == KDecoration3::BorderSize::None;
     }
 
     bool Decoration::hasNoSideBorders() const
     {
         if( m_internalSettings && m_internalSettings->mask() & BorderSize ) return m_internalSettings->borderSize() == InternalSettings::BorderNoSides;
-        else return settings()->borderSize() == KDecoration2::BorderSize::NoSides;
+        else return settings()->borderSize() == KDecoration3::BorderSize::NoSides;
     }
 
     bool Decoration::isMaximized() const
-    { return client()->isMaximized() && !m_internalSettings->drawBorderOnMaximizedWindows(); }
+    { return window()->isMaximized() && !m_internalSettings->drawBorderOnMaximizedWindows(); }
 
     bool Decoration::isMaximizedHorizontally() const
-    { return client()->isMaximizedHorizontally() && !m_internalSettings->drawBorderOnMaximizedWindows(); }
+    { return window()->isMaximizedHorizontally() && !m_internalSettings->drawBorderOnMaximizedWindows(); }
 
     bool Decoration::isMaximizedVertically() const
-    { return client()->isMaximizedVertically() && !m_internalSettings->drawBorderOnMaximizedWindows(); }
+    { return window()->isMaximizedVertically() && !m_internalSettings->drawBorderOnMaximizedWindows(); }
 
     bool Decoration::isLeftEdge() const
-    { return (client()->isMaximizedHorizontally() || client()->adjacentScreenEdges().testFlag( Qt::LeftEdge ) ) && !m_internalSettings->drawBorderOnMaximizedWindows(); }
+    { return (window()->isMaximizedHorizontally() || window()->adjacentScreenEdges().testFlag( Qt::LeftEdge ) ) && !m_internalSettings->drawBorderOnMaximizedWindows(); }
 
     bool Decoration::isRightEdge() const
-    { return (client()->isMaximizedHorizontally() || client()->adjacentScreenEdges().testFlag( Qt::RightEdge ) ) && !m_internalSettings->drawBorderOnMaximizedWindows(); }
+    { return (window()->isMaximizedHorizontally() || window()->adjacentScreenEdges().testFlag( Qt::RightEdge ) ) && !m_internalSettings->drawBorderOnMaximizedWindows(); }
 
     bool Decoration::isTopEdge() const
-    { return (client()->isMaximizedVertically() || client()->adjacentScreenEdges().testFlag( Qt::TopEdge ) ) && !m_internalSettings->drawBorderOnMaximizedWindows(); }
+    { return (window()->isMaximizedVertically() || window()->adjacentScreenEdges().testFlag( Qt::TopEdge ) ) && !m_internalSettings->drawBorderOnMaximizedWindows(); }
 
     bool Decoration::isBottomEdge() const
-    { return (client()->isMaximizedVertically() || client()->adjacentScreenEdges().testFlag( Qt::BottomEdge ) ) && !m_internalSettings->drawBorderOnMaximizedWindows(); }
+    { return (window()->isMaximizedVertically() || window()->adjacentScreenEdges().testFlag( Qt::BottomEdge ) ) && !m_internalSettings->drawBorderOnMaximizedWindows(); }
 
     bool Decoration::hideTitleBar() const
-    { return m_internalSettings->hideTitleBar() == 3 || ( m_internalSettings->hideTitleBar() == 1 && client()->isMaximized() ) || ( m_internalSettings->hideTitleBar() == 2 && ( client()->isMaximized() || client()->isMaximizedVertically()  || client()->isMaximizedHorizontally()) ); }
+    { return m_internalSettings->hideTitleBar() == 3 || ( m_internalSettings->hideTitleBar() == 1 && window()->isMaximized() ) || ( m_internalSettings->hideTitleBar() == 2 && ( window()->isMaximized() || window()->isMaximizedVertically()  || window()->isMaximizedHorizontally()) ); }
 
     int Decoration::titleBarAlpha() const
     {

--- a/breezesettingsprovider.cpp
+++ b/breezesettingsprovider.cpp
@@ -74,7 +74,7 @@ namespace Breeze
         QString windowClass;
 
         // get the client
-        const auto client = decoration->client();
+        const auto client = decoration->window();
 
         foreach( auto internalSettings, m_exceptions )
         {

--- a/breezesizegrip.cpp
+++ b/breezesizegrip.cpp
@@ -20,7 +20,7 @@
 
 #include "breezesizegrip.h"
 
-#include <KDecoration2/DecoratedClient>
+#include <KDecoration3/DecoratedWindow>
 
 #include <QPainter>
 #include <QPolygon>
@@ -62,10 +62,10 @@ namespace Breeze
         updatePosition();
 
         // connections
-        auto c = decoration->client();
-        connect( c, &KDecoration2::DecoratedClient::widthChanged, this, &SizeGrip::updatePosition );
-        connect( c, &KDecoration2::DecoratedClient::heightChanged, this, &SizeGrip::updatePosition );
-        connect( c, &KDecoration2::DecoratedClient::activeChanged, this, &SizeGrip::updateActiveState );
+        auto c = decoration->window();
+        connect( c, &KDecoration3::DecoratedWindow::widthChanged, this, &SizeGrip::updatePosition );
+        connect( c, &KDecoration3::DecoratedWindow::heightChanged, this, &SizeGrip::updatePosition );
+        connect( c, &KDecoration3::DecoratedWindow::activeChanged, this, &SizeGrip::updateActiveState );
 
         // show
         show();
@@ -99,9 +99,9 @@ namespace Breeze
         #if BREEZE_HAVE_X11
 
         if( !QX11Info::isPlatformX11() ) return;
-        auto c = m_decoration.data()->client();
+        auto c = m_decoration.data()->window();
 
-        xcb_window_t windowId = c->windowId();
+        xcb_window_t windowId = QX11Info::appRootWindow(); //FIXME: looking for client but don't know how
         if( windowId )
         {
 
@@ -191,7 +191,7 @@ namespace Breeze
         #if BREEZE_HAVE_X11
         if( !QX11Info::isPlatformX11() ) return;
 
-        auto c = m_decoration.data()->client();
+        auto c = m_decoration.data()->window();
         QPoint position(
             c->width() - GripSize - Offset,
             c->height() - GripSize - Offset );
@@ -213,7 +213,7 @@ namespace Breeze
         auto connection( QX11Info::connection() );
 
         // client
-        auto c = m_decoration.data()->client();
+        auto c = m_decoration.data()->window();
 
         /*
         get root position matching position
@@ -283,7 +283,7 @@ namespace Breeze
         clientMessageEvent.response_type = XCB_CLIENT_MESSAGE;
         clientMessageEvent.type = m_moveResizeAtom;
         clientMessageEvent.format = 32;
-        clientMessageEvent.window = c->windowId();
+        // clientMessageEvent.window = c->windowId(); // FIXME: need to find a way to get windowId
         clientMessageEvent.data.data32[0] = rootPosition.x();
         clientMessageEvent.data.data32[1] = rootPosition.y();
         clientMessageEvent.data.data32[2] = 4; // bottom right

--- a/breezesizegrip.cpp
+++ b/breezesizegrip.cpp
@@ -99,31 +99,31 @@ namespace Breeze
         #if BREEZE_HAVE_X11
 
         if( !QX11Info::isPlatformX11() ) return;
-        auto c = m_decoration.data()->window();
+        // auto c = m_decoration.data()->window();
 
-        xcb_window_t windowId = QX11Info::appRootWindow(); //FIXME: looking for client but don't know how
-        if( windowId )
-        {
+        // xcb_window_t windowId = QX11Info::appRootWindow(); //FIXME: looking for client but don't know how
+        // if( windowId )
+        // {
 
-            /*
-            find client's parent
-            we want the size grip to be at the same level as the client in the stack
-            */
-            xcb_window_t current = windowId;
-            auto connection = QX11Info::connection();
-            xcb_query_tree_cookie_t cookie = xcb_query_tree_unchecked( connection, current );
-            ScopedPointer<xcb_query_tree_reply_t> tree(xcb_query_tree_reply( connection, cookie, nullptr ) );
-            if( !tree.isNull() && tree->parent ) current = tree->parent;
+        //     /*
+        //     find client's parent
+        //     we want the size grip to be at the same level as the client in the stack
+        //     */
+        //     xcb_window_t current = windowId;
+        //     auto connection = QX11Info::connection();
+        //     xcb_query_tree_cookie_t cookie = xcb_query_tree_unchecked( connection, current );
+        //     ScopedPointer<xcb_query_tree_reply_t> tree(xcb_query_tree_reply( connection, cookie, nullptr ) );
+        //     if( !tree.isNull() && tree->parent ) current = tree->parent;
 
-            // reparent
-            xcb_reparent_window( connection, winId(), current, 0, 0 );
-            setWindowTitle( "Breeze::SizeGrip" );
+        //     // reparent
+        //     xcb_reparent_window( connection, winId(), current, 0, 0 );
+        //     setWindowTitle( "Breeze::SizeGrip" );
 
-        } else {
+        // } else {
 
-            hide();
+        //     hide();
 
-        }
+        // }
 
         #endif
     }
@@ -193,8 +193,8 @@ namespace Breeze
 
         auto c = m_decoration.data()->window();
         QPoint position(
-            c->width() - GripSize - Offset,
-            c->height() - GripSize - Offset );
+            c->width() - static_cast<double>(GripSize) - static_cast<double>(Offset),
+            c->height() - static_cast<double>(GripSize) - static_cast<double>(Offset) );
 
         quint32 values[2] = { quint32(position.x()), quint32(position.y()) };
         xcb_configure_window( QX11Info::connection(), winId(), XCB_CONFIG_WINDOW_X | XCB_CONFIG_WINDOW_Y, values );
@@ -213,7 +213,7 @@ namespace Breeze
         auto connection( QX11Info::connection() );
 
         // client
-        auto c = m_decoration.data()->window();
+        // auto c = m_decoration.data()->window(); // FIXME: need to find a way to get windowId
 
         /*
         get root position matching position

--- a/config/breezeconfigwidget.cpp
+++ b/config/breezeconfigwidget.cpp
@@ -48,18 +48,18 @@ namespace Breeze
         // track ui changes
         connect( m_ui.titleAlignment, SIGNAL(currentIndexChanged(int)), SLOT(updateChanged()) );
         connect( m_ui.buttonSize, SIGNAL(currentIndexChanged(int)), SLOT(updateChanged()) );
-        connect( m_ui.buttonSpacing, QOverload<int>::of(&QSpinBox::valueChanged), [=](int /*i*/){updateChanged();} );
+        connect( m_ui.buttonSpacing, QOverload<int>::of(&QSpinBox::valueChanged), [this](int /*i*/){updateChanged();} );
         connect( m_ui.buttonPadding, SIGNAL(valueChanged(int)), SLOT(updateChanged()) );
         connect( m_ui.hOffset, SIGNAL(valueChanged(int)), SLOT(updateChanged()) );
         connect( m_ui.unisonHovering, &QAbstractButton::clicked, this, &ConfigWidget::updateChanged );
-        connect( m_ui.cornerRadiusSpinBox, QOverload<int>::of(&QSpinBox::valueChanged), [=](int /*i*/){updateChanged();} );
+        connect( m_ui.cornerRadiusSpinBox, QOverload<int>::of(&QSpinBox::valueChanged), [this](int /*i*/){updateChanged();} );
         connect( m_ui.drawBorderOnMaximizedWindows, &QAbstractButton::clicked, this, &ConfigWidget::updateChanged );
         connect( m_ui.drawSizeGrip, &QAbstractButton::clicked, this, &ConfigWidget::updateChanged );
         connect( m_ui.opaqueTitleBar, &QAbstractButton::clicked, this, &ConfigWidget::updateChanged );
         connect( m_ui.drawBackgroundGradient, &QAbstractButton::clicked, this, &ConfigWidget::updateChanged );
         connect( m_ui.buttonStyle, SIGNAL(currentIndexChanged(int)), SLOT(updateChanged()) );
-        connect( m_ui.opacitySpinBox, QOverload<int>::of(&QSpinBox::valueChanged), [=](int /*i*/){updateChanged();} );
-        connect( m_ui.gradientSpinBox, QOverload<int>::of(&QSpinBox::valueChanged), [=](int /*i*/){updateChanged();} );
+        connect( m_ui.opacitySpinBox, QOverload<int>::of(&QSpinBox::valueChanged), [this](int /*i*/){updateChanged();} );
+        connect( m_ui.gradientSpinBox, QOverload<int>::of(&QSpinBox::valueChanged), [this](int /*i*/){updateChanged();} );
         connect( m_ui.drawTitleBarSeparator, &QAbstractButton::clicked, this, &ConfigWidget::updateChanged );
         connect( m_ui.hideTitleBar, SIGNAL(currentIndexChanged(int)), SLOT(updateChanged()) );
         connect( m_ui.matchColorForTitleBar, &QAbstractButton::clicked, this, &ConfigWidget::updateChanged );

--- a/config/breezeexceptiondialog.cpp
+++ b/config/breezeexceptiondialog.cpp
@@ -59,10 +59,10 @@ namespace Breeze
         connect( m_ui.drawTitleBarSeparator, &QAbstractButton::clicked, this, &ExceptionDialog::updateChanged );
         connect( m_ui.drawBackgroundGradient, &QAbstractButton::clicked, this, &ExceptionDialog::updateChanged );
         m_ui.gradientOverrideLabelSpinBox->setSpecialValueText(tr("None"));
-        connect( m_ui.gradientOverrideLabelSpinBox, QOverload<int>::of(&QSpinBox::valueChanged), [=](int /*i*/){updateChanged();} );
+        connect( m_ui.gradientOverrideLabelSpinBox, QOverload<int>::of(&QSpinBox::valueChanged), [this](int /*i*/){updateChanged();} );
         connect( m_ui.opaqueTitleBar, &QAbstractButton::clicked, this, &ExceptionDialog::updateChanged );
         m_ui.opacityOverrideLabelSpinBox->setSpecialValueText(tr("None"));
-        connect( m_ui.opacityOverrideLabelSpinBox, QOverload<int>::of(&QSpinBox::valueChanged), [=](int /*i*/){updateChanged();} );
+        connect( m_ui.opacityOverrideLabelSpinBox, QOverload<int>::of(&QSpinBox::valueChanged), [this](int /*i*/){updateChanged();} );
         connect( m_ui.isDialog, &QAbstractButton::clicked, this, &ExceptionDialog::updateChanged );
     }
 

--- a/config/sierrabreezeenhancedconfig.desktop
+++ b/config/sierrabreezeenhancedconfig.desktop
@@ -4,7 +4,7 @@ Icon=preferences-system-windows
 Type=Service
 X-KDE-ServiceTypes=KCModule
 
-X-KDE-Library=org.kde.kdecoration2/sierrabreezeenhanced
+X-KDE-Library=org.kde.kdecoration3/sierrabreezeenhanced
 X-KDE-PluginKeyword=kcmodule
 X-KDE-ParentApp=kcontrol
 X-KDE-Weight=60

--- a/libbreezecommon/breezeboxshadowrenderer.h
+++ b/libbreezecommon/breezeboxshadowrenderer.h
@@ -1,105 +1,83 @@
 /*
- * Copyright (C) 2018 Vlad Zahorodnii <vlad.zahorodnii@kde.org>
+ * SPDX-FileCopyrightText: 2018 Vlad Zahorodnii <vlad.zahorodnii@kde.org>
  *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-#pragma once
-
+ #pragma once
 // own
 #include "breezecommon_export.h"
-
-// Qt
-#include <QColor>
-#include <QImage>
-#include <QPoint>
-#include <QSize>
-
-namespace Breeze
-{
-
-class BREEZECOMMON_EXPORT BoxShadowRenderer
-{
-public:
-    // Compiler generated constructors & destructor are fine.
-
-    /**
-     * Set the size of the box.
-     * @param size The size of the box.
-     **/
-    void setBoxSize(const QSize &size);
-
-    /**
-     * Set the radius of box' corners.
-     * @param radius The border radius, in pixels.
-     **/
-    void setBorderRadius(qreal radius);
-
-    /**
-     * Set the device pixel ratio of the resulting shadow texture.
-     * @param dpr The device pixel ratio.
-     **/
-    void setDevicePixelRatio(qreal dpr);
-
-    /**
-     * Add a shadow.
-     * @param offset The offset of the shadow.
-     * @param radius The blur radius.
-     * @param color The color of the shadow.
-     **/
-    void addShadow(const QPoint &offset, int radius, const QColor &color);
-
-    /**
-     * Render the shadow.
-     **/
-    QImage render() const;
-
-    /**
-     * Calculate the minimum size of the box.
-     *
-     * This helper computes the minimum size of the box so the shadow behind it has
-     * full its strength.
-     *
-     * @param radius The blur radius of the shadow.
-     **/
-    static QSize calculateMinimumBoxSize(int radius);
-
-    /**
-     * Calculate the minimum size of the shadow texture.
-     *
-     * This helper computes the minimum size of the resulting texture so the shadow
-     * is not clipped.
-     *
-     * @param boxSize The size of the box.
-     * @param radius The blur radius.
-     * @param offset The offset of the shadow.
-     **/
-    static QSize calculateMinimumShadowTextureSize(const QSize &boxSize, int radius, const QPoint &offset);
-
-private:
-    QSize m_boxSize;
-    qreal m_borderRadius = 0.0;
-    qreal m_dpr = 1.0;
-
-    struct Shadow {
-        QPoint offset;
-        int radius;
-        QColor color;
-    };
-
-    QVector<Shadow> m_shadows;
-};
-
-} // namespace Breeze
+ // Qt
+ #include <QColor>
+ #include <QImage>
+ #include <QPoint>
+ #include <QSize>
+ 
+ namespace Breeze
+ {
+ class BREEZECOMMON_EXPORT BoxShadowRenderer
+ {
+ public:
+     // Compiler generated constructors & destructor are fine.
+ 
+     /**
+      * Set the size of the box.
+      * @param size The size of the box.
+      **/
+     void setBoxSize(const QSizeF &size);
+ 
+     /**
+      * Set the radius of box' corners.
+      * @param radius The border radius, in pixels.
+      **/
+     void setBorderRadius(qreal radius);
+ 
+     /**
+      * Add a shadow.
+      * @param offset The offset of the shadow.
+      * @param radius The blur radius.
+      * @param color The color of the shadow.
+      **/
+     void addShadow(const QPointF &offset, double radius, const QColor &color);
+ 
+     /**
+      * Render the shadow.
+      **/
+     QImage render() const;
+ 
+     /**
+      * Calculate the minimum size of the box.
+      *
+      * This helper computes the minimum size of the box so the shadow behind it has
+      * full its strength.
+      *
+      * @param radius The blur radius of the shadow.
+      **/
+     static QSize calculateMinimumBoxSize(int radius);
+ 
+     /**
+      * Calculate the minimum size of the shadow texture.
+      *
+      * This helper computes the minimum size of the resulting texture so the shadow
+      * is not clipped.
+      *
+      * @param boxSize The size of the box.
+      * @param radius The blur radius.
+      * @param offset The offset of the shadow.
+      **/
+     static QSizeF calculateMinimumShadowTextureSize(const QSizeF &boxSize, double radius, const QPointF &offset);
+ 
+ private:
+     QSizeF m_boxSize;
+     qreal m_borderRadius = 0.0;
+ 
+     struct Shadow {
+         QPointF offset;
+         double radius;
+         QColor color;
+     };
+ 
+     QVector<Shadow> m_shadows;
+ };
+ 
+ } // namespace Breeze

--- a/sierrabreezeenhanced.json
+++ b/sierrabreezeenhanced.json
@@ -5,11 +5,11 @@
         "Id": "org.kde.sierrabreezeenhanced",
         "Name": "Sierra Breeze Enhanced",
         "ServiceTypes": [
-            "org.kde.kdecoration2"
+            "org.kde.kdecoration3"
         ]
     },
     "X-KDE-ConfigModule": "kcm_sierrabreezeenhanceddecoration",
-    "org.kde.kdecoration2": {
+    "org.kde.kdecoration3": {
         "defaultTheme": "Sierra Breeze Enhanced",
         "recommendedBorderSize": "Tiny"
     }

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -26,7 +26,7 @@ install_and_uninstall() {
     uninstall
     echo It is possible that some files left over at the following locations
     echo Please remove any files containing sierrabreezeenhanced in their name
-    echo - /usr/lib/qt/plugins/org.kde.kdecoration2/
+    echo - /usr/lib/qt/plugins/org.kde.kdecoration3/
     echo - /usr/share/kservices5/
     echo - /usr/lib/
 }


### PR DESCRIPTION
### Key Changes:

KDecoration2 to KDecoration3 Migration: Replaced the deprecated KDecoration2 API with the new KDecoration3 functionality, ensuring compatibility with Plasma 6.3.
Window Handling Update: Due to the removal of windowId in KDecoration3, adjustments were made to handle window identification with alternative methods.

### Pending Tasks:

Implement `breezegrip` for X11: Since `windowId` has been removed in KDecoration3, the `breezegrip` section for X11 needs to be implemented to ensure proper window handling. I can implement if somebody can help me to find exactly how to get decoration windowId.

### Tested On:

    KDE Neon Plasma 6.3