### PR TITLE
Bump Up The Version In CmakeLists To Get Rid Of Errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(sierrabreezeenhanced)
-set(PROJECT_VERSION "2.1.0")
+set(PROJECT_VERSION "3.5.0")
 set(PROJECT_VERSION_MAJOR 0)
 
 cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)


### PR DESCRIPTION
It was showing this error when i tried to install it from source from arch inux.
```
CMake Error at CMakeLists.txt:5 (cmake_minimum_required):
Compatibility with CMake < 3.5 has been removed from CMake.

Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
to tell CMake that the project requires at least <min> but has been updated
to work with policies introduced by <max> or earlier.

Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```

So, I bumped up the version as there doesn't seem to be any problems with that