### PR TITLE
Add GuiPrivate to findpackages for QT 6.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ find_package(
                                              ConfigWidgets WindowSystem I18n)
 find_package(Qt${QT_MAJOR_VERSION} ${QT_MIN_VERSION} CONFIG REQUIRED
              COMPONENTS Widgets DBus)
-find_package(Qt6 REQUIRED COMPONENTS Core5Compat)
+find_package(Qt6 REQUIRED COMPONENTS Core5Compat GuiPrivate)
 
 # XCB
 find_package(XCB COMPONENTS XCB)


### PR DESCRIPTION
Wouldn't build on QT 6.10 without adding GuiPrivate to find_packages, tested on CachyOS with Plasma 6.4.5, QT 6.10.0